### PR TITLE
fix the ut tests so they pass

### DIFF
--- a/source/pkg/adapter/adapter_test.go
+++ b/source/pkg/adapter/adapter_test.go
@@ -19,18 +19,19 @@ package rabbitmq
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/sbcd90/wabbit/amqp"
 	"github.com/sbcd90/wabbit/amqptest"
 	"github.com/sbcd90/wabbit/amqptest/server"
 	origamqp "github.com/streadway/amqp"
 	"go.uber.org/zap"
-	"io/ioutil"
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/pkg/source"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 func TestPostMessage_ServeHttp(t *testing.T) {
@@ -447,7 +448,10 @@ func TestAdapter_JsonEncode(t *testing.T) {
 		logger:   zap.NewNop(),
 		reporter: statsReporter,
 	}
-	data := a.JsonEncode([]byte("test json"))
+	data, err := a.JsonEncode([]byte(`{"Test":"json"}`))
+	if err != nil {
+		t.Errorf("JsonEncode failed: %s", err)
+	}
 	if data == nil {
 		t.Errorf("Json decoded incorrectly")
 	}

--- a/source/pkg/apis/sources/v1alpha1/rabbitmq_lifecycle_test.go
+++ b/source/pkg/apis/sources/v1alpha1/rabbitmq_lifecycle_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
@@ -24,7 +26,6 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"testing"
 )
 
 var (
@@ -216,7 +217,7 @@ func TestRabbitmqSourceStatusGetCondition(t *testing.T) {
 			Type:    RabbitmqConditionReady,
 			Status:  corev1.ConditionUnknown,
 			Reason:  "SinkEmpty",
-			Message: "Sink has resolved to empty.",
+			Message: "Sink has resolved to empty",
 		},
 	}, {
 		name: "mark sink empty and deployed then sink",


### PR DESCRIPTION
Fix the tests that were failing when running go test ./... from the root.

```
# knative.dev/eventing-rabbitmq/source/pkg/adapter [knative.dev/eventing-rabbitmq/source/pkg/adapter.test]
source/pkg/adapter/adapter_test.go:450:7: assignment mismatch: 1 variable but a.JsonEncode returns 2 values
```

And:
```
--- FAIL: TestRabbitmqSourceStatusGetCondition (0.00s)
    --- FAIL: TestRabbitmqSourceStatusGetCondition/mark_sink_empty_and_deployed_and_event_types (0.00s)
        rabbitmq_lifecycle_test.go:244: unexpected condition (-want, +got) =   &apis.Condition{
              	... // 2 ignored and 2 identical fields
              	Reason:  "SinkEmpty",
            - 	Message: "Sink has resolved to empty.",
            + 	Message: "Sink has resolved to empty",
              }
FAIL
FAIL	knative.dev/eventing-rabbitmq/source/pkg/apis/sources/v1alpha1	1.079s
```
