### PR TITLE
Adding Rigging for e2e tests.

### DIFF
--- a/.github/workflows/go-pr-build.yaml
+++ b/.github/workflows/go-pr-build.yaml
@@ -1,0 +1,55 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build
+
+on:
+  push:
+    branches: [ 'master', 'release-*' ]
+  pull_request:
+    branches: [ 'master', 'release-*' ]
+
+jobs:
+
+  build:
+    name: Build
+    strategy:
+      matrix:
+        go-version: [1.14.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      - name: Check out code onto GOPATH
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+
+      - name: Vet
+        run: go vet knative.dev/${{github.event.pull_request.head.repo.name}}/...
+
+      - name: Build
+        run: go build -v knative.dev/${{github.event.pull_request.head.repo.name}}/...

--- a/.github/workflows/go-pr-style.yaml
+++ b/.github/workflows/go-pr-style.yaml
@@ -1,0 +1,66 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Code Style
+
+on:
+  push:
+    branches: [ 'master', 'release-*' ]
+  pull_request:
+    branches: [ 'master', 'release-*' ]
+
+jobs:
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+      - name: Set up Go 1.14.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14.x
+        id: go
+
+      - name: Check out code onto GOPATH
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+
+      # TODO: add prettier step
+
+      - name: Go Format
+        shell: bash
+        run: |
+          pushd ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+          gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -type f -name '*.go' -print)
+          popd
+
+      - name: Verify
+        shell: bash
+        run: |
+          pushd ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+          if [[ $(git diff-index --name-only HEAD --) ]]; then
+              echo "Found diffs in:"
+              git diff-index --name-only HEAD --
+              echo "${{ github.repository }} is out of style. Please run go fmt."
+              exit 1
+          fi
+          echo "${{ github.repository }} is formatted correctly."
+          popd

--- a/.github/workflows/go-pr-test.yaml
+++ b/.github/workflows/go-pr-test.yaml
@@ -1,0 +1,52 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test
+
+on:
+  push:
+    branches: [ 'master', 'release-*' ]
+  pull_request:
+    branches: [ 'master', 'release-*' ]
+
+jobs:
+
+  test:
+    name: Test
+    strategy:
+      matrix:
+        go-version: [1.14.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      - name: Check out code onto GOPATH
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+
+      - name: Test
+        run: go test -race knative.dev/${{github.event.pull_request.head.repo.name}}/...

--- a/.github/workflows/go-pr-verify.yaml
+++ b/.github/workflows/go-pr-verify.yaml
@@ -1,0 +1,75 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Verify
+
+on:
+  push:
+    branches: [ 'master', 'release-*' ]
+  pull_request:
+    branches: [ 'master', 'release-*' ]
+
+jobs:
+
+  verify:
+    name: Verify Deps and Codegen
+    strategy:
+      matrix:
+        go-version: [1.14.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/ko/cmd/ko
+        go get github.com/google/go-licenses
+
+    - name: Check out code onto GOPATH
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        path: ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+
+    - name: Update Codegen
+      shell: bash
+      run: |
+        pushd ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+        ./hack/update-codegen.sh
+        popd
+
+    - name: Verify
+      shell: bash
+      run: |
+        pushd ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+        if [[ -z "$(git status --porcelain)" ]]; then
+            echo "${{ github.repository }} up to date."
+        else
+            repoDiff=$(git diff-index --name-only HEAD --)
+            echo "Found diffs in: $repoDiff"
+            echo "${{ github.repository }} is out of date. Please run hack/update-codegen.sh"
+            exit 1
+        fi
+        popd

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -1,0 +1,113 @@
+name: KinD e2e tests
+
+on:
+  push:
+    branches: [ 'master', 'release-*' ]
+  pull_request:
+    branches: [ 'master', 'release-*' ]
+
+jobs:
+
+  ko-resolve:
+    name: e2e tests
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+      GO111MODULE: off
+      KO_DOCKER_REPO: ko.local
+
+    steps:
+    - name: Set up Go 1.14.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.14.x
+
+    - name: Install Dependencies
+      run: |
+        GO111MODULE=on go get github.com/google/ko/cmd/ko@master
+
+    - name: Check out code onto GOPATH
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        path: ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+
+    - name: Install KinD
+      working-directory: ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+      env:
+        KIND_VERSION: v0.8.1
+      run: |
+        set -x
+
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+
+    - name: Create KinD Cluster
+      working-directory: ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+      run: |
+        set -x
+
+        # KinD configuration.
+        cat > kind.yaml <<EOF
+        apiVersion: kind.x-k8s.io/v1alpha4
+        kind: Cluster
+        nodes:
+        - role: control-plane
+        - role: worker
+        EOF
+
+        # Create a cluster!
+        kind create cluster --config kind.yaml
+
+    - name: Install Knaitve Component
+      working-directory: ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+      run: |
+        set -x
+
+        # Build and Publish our test images to the docker daemon.
+        # ./test/upload-test-images.sh # <-- Skip for now.
+
+        # Build and Publish our containers to the docker daemon (including test assets)
+        export GO111MODULE=on
+        export GOFLAGS=-mod=vendor
+        ko resolve -Pf config/ -f test/config > build.yaml
+
+        # Load our docker images into the kind cluster!
+        for x in $(docker images  --format='{{.Repository}}:{{.Tag}}' | grep ko.local); do
+          kind load docker-image $x
+        done
+
+        # Deploy the controllers we published to the cluster.
+        kubectl apply -f build.yaml
+
+    - name: Install Dependencies
+      working-directory: ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+      run: |
+        set -x
+
+        echo TODO... Install RabbitMQ here. See https://github.com/rabbitmq/cluster-operator
+
+    - name: Wait for Ready
+      working-directory: ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+      run: |
+        set -x
+
+        # Probably don't need this anymore, but keep until we
+        # have something that waits for pods to becomes ready.
+        sleep 60
+
+        # For debugging.
+        kubectl get pods --all-namespaces
+
+    - name: Run e2e Tests
+      working-directory: ./src/knative.dev/${{github.event.pull_request.head.repo.name}}
+      run: |
+        set -x
+
+        # For logstream to work.
+        export SYSTEM_NAMESPACE=knative-eventing # TODO: fix this when we move the namespace.
+
+        # Run the tests tagged as e2e on the KinD cluster.
+        go test -v -race -count=1 -timeout=3m -tags=e2e ./test/e2e/...
+

--- a/test/config/config-logging.yaml
+++ b/test/config/config-logging.yaml
@@ -1,0 +1,44 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: knative-discovery
+  labels:
+    discovery.knative.dev/release: devel
+
+data:
+  zap-logger-config: |
+    {
+      "level": "debug",
+      "development": false,
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "ts",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "iso8601",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }

--- a/test/config/quacken.yaml
+++ b/test/config/quacken.yaml
@@ -1,0 +1,87 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chaosduck
+  namespace: knative-discovery
+  labels:
+    discovery.knative.dev/release: devel
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: chaosduck
+  namespace: knative-discovery
+  labels:
+    discovery.knative.dev/release: devel
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: chaosduck
+  namespace: knative-discovery
+  labels:
+    discovery.knative.dev/release: devel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chaosduck
+subjects:
+- kind: ServiceAccount
+  name: chaosduck
+  namespace: knative-discovery
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chaosduck
+  namespace: knative-discovery
+  labels:
+    discovery.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: chaosduck
+  template:
+    metadata:
+      labels:
+        app: chaosduck
+    spec:
+      serviceAccountName: chaosduck
+      containers:
+      - name: chaosduck
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: ko://knative.dev/pkg/leaderelection/chaosduck
+
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+
+        securityContext:
+          allowPrivilegeEscalation: false

--- a/test/e2e/config/rabbitmq/cluster.yaml
+++ b/test/e2e/config/rabbitmq/cluster.yaml
@@ -16,6 +16,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: rabbitmqc
-  namespace: default #{{ .namespace }}
+  namespace: {{ .namespace }}
 spec:
   replicas: 1

--- a/test/e2e/config/rabbitmq/cluster.yaml
+++ b/test/e2e/config/rabbitmq/cluster.yaml
@@ -1,0 +1,21 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: rabbitmqc
+  namespace: default #{{ .namespace }}
+spec:
+  replicas: 1

--- a/test/e2e/config/smoke/broker/smoke.yaml
+++ b/test/e2e/config/smoke/broker/smoke.yaml
@@ -1,0 +1,29 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+---
+
+apiVersion: eventing.knative.dev/v1beta1
+kind: Broker
+metadata:
+  name: smoke
+  annotations:
+    eventing.knative.dev/broker.class: RabbitMQBroker
+spec:
+  config:
+    apiVersion: v1
+    kind: Secret
+    name: smoke-rabbitmq-broker-secret

--- a/test/e2e/config/smoke/broker/smoke.yaml
+++ b/test/e2e/config/smoke/broker/smoke.yaml
@@ -12,18 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
----
-
 apiVersion: eventing.knative.dev/v1beta1
 kind: Broker
 metadata:
   name: smoke
+  namespace: {{ .namespace }}
   annotations:
     eventing.knative.dev/broker.class: RabbitMQBroker
 spec:
   config:
     apiVersion: v1
     kind: Secret
-    name: smoke-rabbitmq-broker-secret
+    name: rabbitmqc-rabbitmq-admin

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,35 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package example
+
+import (
+	"testing"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"knative.dev/pkg/test/logstream"
+)
+
+// TestSmoke makes sure a ClusterDuckType goes ready.
+func TestSmoke(t *testing.T) {
+	cancel := logstream.Start(t) // I think there is more to do to get logstream to work.
+	defer cancel()
+
+	SmokeTestImpl(t)
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package example
+package rabbit_test
 
 import (
 	"testing"
@@ -26,10 +26,10 @@ import (
 	"knative.dev/pkg/test/logstream"
 )
 
-// TestSmoke makes sure a ClusterDuckType goes ready.
-func TestSmoke(t *testing.T) {
+// TestSmokeBroker makes sure a Broker goes ready as a RabbitMQ Broker Class.
+func TestSmokeBroker(t *testing.T) {
 	cancel := logstream.Start(t) // I think there is more to do to get logstream to work.
 	defer cancel()
 
-	SmokeTestImpl(t)
+	SmokeTestBrokerImpl(t)
 }

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package example
+package rabbit_test
 
 import (
 	"github.com/n3wscott/rigging"
@@ -26,7 +26,7 @@ import (
 func SmokeTesBrokertImpl(t *testing.T) {
 	opts := []rigging.Option{}
 
-	rig, err := rigging.NewInstall(opts, []string{"smoke/broker"}, map[string]string{})
+	rig, err := rigging.NewInstall(opts, []string{"rabbitmq", "smoke/broker"}, map[string]string{})
 	if err != nil {
 		t.Fatalf("failed to create rig, %s", err)
 	}

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package example
+
+import (
+	"github.com/n3wscott/rigging"
+	"testing"
+	"time"
+)
+
+// SmokeTestBrokerImpl makes sure an RabbitMQ Broker goes ready.
+func SmokeTesBrokertImpl(t *testing.T) {
+	opts := []rigging.Option{}
+
+	rig, err := rigging.NewInstall(opts, []string{"smoke/broker"}, map[string]string{})
+	if err != nil {
+		t.Fatalf("failed to create rig, %s", err)
+	}
+	t.Logf("Created a new testing rig at namespace %s.", rig.Namespace())
+
+	// Uninstall deferred.
+	defer func() {
+		if err := rig.Uninstall(); err != nil {
+			t.Errorf("failed to uninstall, %s", err)
+		}
+	}()
+
+	refs := rig.Objects()
+	for _, r := range refs {
+		_, err := rig.WaitForReadyOrDone(r, 45*time.Second)
+		if err != nil {
+			t.Fatalf("failed to wait for ready or done, %s", err)
+		}
+		// Pass!
+	}
+}

--- a/test/kind/README.md
+++ b/test/kind/README.md
@@ -1,0 +1,27 @@
+# Using KinD
+
+The following is what is needed to use KinD to run the e2e tests. Base path is assumed to be the top level project.
+
+Startup a cluster:
+
+```shell
+./test/kind/bootstrap.sh
+```
+
+Install the Eventing Rabbit Controllers:
+
+```shell
+./test/kind/install.sh
+```
+
+Run the end to end tests:
+
+```shell
+./test/kind/run-tests.sh
+```
+
+Cleanup:
+
+```shell
+./test/kind/bootstrap.sh --shutdown
+```

--- a/test/kind/bootstrap.sh
+++ b/test/kind/bootstrap.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+# Supported flags:
+# Set an alternate name on the cluster, defaults to kink
+#   --name "alternate-cluster-name"
+# Verify the installation:
+#   --check
+# Set registry port, defaults to 5000
+#   --reg-port 1337
+#
+
+# create registry container unless it already exists
+cluster_name=knik
+reg_name='kind-registry'
+reg_port='5000'
+node_image='kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765'
+
+# Parse flags to determine any we should pass to dep.
+check=0
+shutdown=0
+while [[ $# -ne 0 ]]; do
+  parameter=$1
+  case ${parameter} in
+    --check) check=1 ;;
+    --shutdown) shutdown=1 ;;
+    *)
+      [[ $# -ge 2 ]] || abort "missing parameter after $1"
+      shift
+      case ${parameter} in
+        --name) cluster_name=$1 ;;
+        --reg-port) reg_port=$1 ;;
+        *) abort "unknown option ${parameter}" ;;
+      esac
+  esac
+  shift
+done
+readonly check
+readonly shutdown
+readonly cluster_name
+readonly reg_name
+readonly reg_port
+
+reg_running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+kind_running="$(kind get clusters -q | grep ${cluster_name} || true)"
+
+if (( check )); then
+  if [[ "${kind_running}" ]]; then
+    echo "KinD cluster ${cluster_name} is running"
+  else
+    echo "KinD cluster ${cluster_name} is NOT running"
+  fi
+  if [ "${reg_running}" == 'true' ]; then
+    echo "Docker hosted registry ${reg_name} is running"
+  else
+    echo "Docker hosted registry ${reg_name} is NOT running"
+  fi
+  kind --version
+  docker --version
+  exit 0
+fi
+
+if (( shutdown )); then
+  if [[ "${kind_running}" == "${cluster_name}" ]]; then
+    echo "Deleting KinD cluster ${cluster_name}"
+    kind delete cluster -q --name ${cluster_name}
+  fi
+  if [ "${reg_running}" == 'true' ]; then
+    echo "Stopping docker hosted registry ${reg_name}"
+    docker stop "${reg_name}"
+    docker rm "${reg_name}"
+  fi
+  echo "Shutdown."
+  exit 0
+fi
+
+if [ "${reg_running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --name ${cluster_name} --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: ${node_image}
+- role: worker
+  image: ${node_image}
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:${reg_port}"]
+EOF
+
+# connect the registry to the cluster network
+if [ "${running}" != 'true' ]; then
+  docker network connect "kind" "${reg_name}"
+fi
+
+# tell https://tilt.dev to use the registry
+# https://docs.tilt.dev/choosing_clusters.html#discovering-the-registry
+for node in $(kind get nodes); do
+  kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${reg_port}";
+done
+
+echo "To use local registry:"
+echo "export KO_DOCKER_REPO=localhost:${reg_port}"

--- a/test/kind/install.sh
+++ b/test/kind/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+readonly ROOT_DIR=$(dirname $0)/../..
+[[ ! -v REPO_ROOT_DIR ]] && REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
+readonly REPO_ROOT_DIR
+
+readonly reg_port='5000'
+
+export KO_DOCKER_REPO=localhost:${reg_port}
+
+pwd
+
+echo "Installing Knative Eventing RabbitMQ API"
+
+ko apply -f ${REPO_ROOT_DIR}/config

--- a/test/kind/run-tests.sh
+++ b/test/kind/run-tests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+readonly ROOT_DIR=$(dirname $0)/../..
+[[ ! -v REPO_ROOT_DIR ]] && REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
+readonly REPO_ROOT_DIR
+
+readonly reg_port='5000'
+
+export KO_DOCKER_REPO=localhost:${reg_port}
+
+echo "Starting End-to-End tests for Knative Eventing RabbitMQ API"
+
+go test -v -tags=e2e -count=1 ${REPO_ROOT_DIR}/test/e2e


### PR DESCRIPTION
And github actions for ci.

Note: this is not working yet. Don't expect it to pass e2e. Still need to figure out how to get the upstream operator for RabbitMQ to get installed into kind here.