### PR TITLE
only reconcile my own triggers

### DIFF
--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -143,12 +143,15 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *v1beta1.Broker) pkgre
 		Host:   names.ServiceHostName(ingressEndpoints.GetName(), ingressEndpoints.GetNamespace()),
 	})
 
-	_, err = r.reconcileScaleTriggerAuthentication(ctx, b)
-	if err != nil {
-		logging.FromContext(ctx).Errorw("Problem creating TriggerAuthentication", zap.Error(err))
-		b.Status.MarkIngressFailed("TriggerAuthenticationFailure", "%v", err)
-		return err
-	}
+	// Do this after we sort out Keda 2.0 versioning.
+	/*
+		_, err = r.reconcileScaleTriggerAuthentication(ctx, b)
+		if err != nil {
+			logging.FromContext(ctx).Errorw("Problem creating TriggerAuthentication", zap.Error(err))
+			b.Status.MarkIngressFailed("TriggerAuthenticationFailure", "%v", err)
+			return err
+		}
+	*/
 
 	// So, at this point the Broker is ready and everything should be solid
 	// for the triggers to act upon.

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -84,6 +84,7 @@ func NewController(
 		scaledObjectLister:           scaledObjectInformer.Lister(),
 		dispatcherImage:              env.DispatcherImage,
 		dispatcherServiceAccountName: env.DispatcherServiceAccount,
+		brokerClass:                  env.BrokerClass,
 	}
 
 	impl := triggerreconciler.NewImpl(ctx, r)


### PR DESCRIPTION
Only reconcile my triggers. While we only enqueue our triggers on broker changes, during global resync they would also get queued.
While we're migrating to new Keda, disable it until things settle down there. Will be apparently fixed in upstream in a matter of days...