### PR TITLE
use the passed in duration, clean readme

### DIFF
--- a/samples/broker/dlq/README.md
+++ b/samples/broker/dlq/README.md
@@ -225,9 +225,9 @@ vaikas-a01:wabbit vaikas$ kubectl -n dlq-demo -l='serving.knative.dev/service=fa
 ```
 
 You see there are both 200 / 503 events there. And more importantly, you can see
-that 200 is only sent once to the failer since it's processed
-correctly. However, the 503 is sent a total of 6 times because we have specified
-the retry of 5 (original, plus 5 retries for a total of 6 log entries).
+that 200 is only sent once to the failer since it's processed correctly.
+However, the 503 is sent a total of 6 times because we have specified the retry
+of 5 (original, plus 5 retries for a total of 6 log entries).
 
 However the event-display (the Dead Letter Sink) only sees the failed events
 with the response code set to 503.

--- a/samples/broker/dlq/README.md
+++ b/samples/broker/dlq/README.md
@@ -224,7 +224,7 @@ vaikas-a01:wabbit vaikas$ kubectl -n dlq-demo -l='serving.knative.dev/service=fa
 2020/10/06 10:35:03 using response code: 503
 ```
 
-You see there are both 200 / 503 events there. And more importanly, you can see
+You see there are both 200 / 503 events there. And more importantly, you can see
 that 200 is only sent once to the failer since it's processed
 correctly. However, the 503 is sent a total of 6 times because we have specified
 the retry of 5 (original, plus 5 retries for a total of 6 log entries).

--- a/samples/broker/dlq/README.md
+++ b/samples/broker/dlq/README.md
@@ -15,7 +15,7 @@ Sink while successfully processed events do not.
 - [failer](../../../cmd/failer/main.go) is a function which takes in a
   CloudEvent and depending on what the specified HTTP response code in the
   message data is will respond with that. So, to simulate a failure, we just
-  send it a CloudEvent with a payload of 500 and it's going to simulate a
+  send it a CloudEvent with a payload of 503 and it's going to simulate a
   failure, by default it will respond with a 200, hence indicating that it
   processed the event successfully and it should be considered handled.
 
@@ -31,7 +31,7 @@ Sink while successfully processed events do not.
 
 Demo creates two `PingSource`s and has them send an event once a minute. One of
 them sends an event that has responsecode set to 200 (event processed
-successfully) and one that has responsecode set to 500 (event processing
+successfully) and one that has responsecode set to 503 (event processing
 failed).
 
 Demo creates a `Broker` with the delivery configuration that specifies that
@@ -170,7 +170,7 @@ metadata:
   namespace: dlq-demo
 spec:
   schedule: "*/1 * * * *"
-  jsonData: '{"responsecode": 500}'
+  jsonData: '{"responsecode": 503}'
   sink:
     ref:
       apiVersion: eventing.knative.dev/v1beta1
@@ -206,41 +206,45 @@ EOF
 ### Create Failer
 
 ```sh
-ko apply -n dlq-demo -f ./config/failer
+kubectl apply -f 'https://storage.googleapis.com/knative-nightly/eventing-rabbitmq/latest/failer.yaml'
 ```
 
 ### Check the results
 
-Look at the failer pod logs, you see it's receiving both 200/500 responses.
+Look at the failer pod logs, you see it's receiving both 200/503 responses.
 
 ```sh
 vaikas-a01:wabbit vaikas$ kubectl -n dlq-demo -l='serving.knative.dev/service=failer' logs -c user-container
-2020/10/02 11:35:00 using response code: 500
-2020/10/02 11:35:00 using response code: 200
-2020/10/02 11:36:00 using response code: 200
-2020/10/02 11:36:00 using response code: 500
-2020/10/02 11:37:00 using response code: 200
-2020/10/02 11:37:00 using response code: 500
-2020/10/02 11:38:00 using response code: 200
-2020/10/02 11:38:00 using response code: 500
-2020/10/02 11:39:00 using response code: 500
+2020/10/06 10:35:00 using response code: 200
+2020/10/06 10:35:00 using response code: 503
+2020/10/06 10:35:00 using response code: 503
+2020/10/06 10:35:00 using response code: 503
+2020/10/06 10:35:01 using response code: 503
+2020/10/06 10:35:01 using response code: 503
+2020/10/06 10:35:03 using response code: 503
 ```
 
-You see there are both 200 / 500 events there.
+You see there are both 200 / 503 events there. And more importanly, you can see
+that 200 is only sent once to the failer since it's processed
+correctly. However, the 503 is sent a total of 6 times because we have specified
+the retry of 5 (original, plus 5 retries for a total of 6 log entries).
 
 However the event-display (the Dead Letter Sink) only sees the failed events
-with the response code set to 500.
+with the response code set to 503.
 
 ```sh
 vaikas-a01:wabbit vaikas$ kubectl -n dlq-demo -l='serving.knative.dev/service=event-display' logs -c user-container
+☁️  cloudevents.Event
+Validation: valid
+Context Attributes,
   specversion: 1.0
   type: dev.knative.sources.ping
   source: /apis/v1/namespaces/dlq-demo/pingsources/ping-source-2
-  id: 11bb6bd0-c1df-4181-9139-b02126fde1a7
-  time: 2020-10-02T11:43:00.053647633Z
+  id: 166e89ff-19c7-4e9a-a593-9ed30dca0d7d
+  time: 2020-10-06T10:35:00.307531386Z
   datacontenttype: application/json
 Data,
   {
-    "responsecode": 500
+    "responsecode": 503
   }
 ```


### PR DESCRIPTION
Turns out the cloudevents sdk does NOT retry on 500, so changed the example to 503 to show the retries. Also, use the passed in duration instead of ignoring it.