### PR TITLE
Test with k8s 17, 18 and 19. Use 18.4 for eventing.

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -78,15 +78,15 @@ jobs:
       run: |
         set -x
 
-        kubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/download/0.46.0/cluster-operator.yml
+        kubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/download/0.48.0/cluster-operator.yml
 
     - name: Install Knative Eventing
       run: |
         set -x
 
-        kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.17.0/eventing-crds.yaml
+        kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.18.4/eventing-crds.yaml
         sleep 2 # Wait for the CRDs to be reconciled.
-        kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.17.0/eventing-core.yaml
+        kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.18.4/eventing-core.yaml
 
     - name: Install
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -117,6 +117,19 @@ jobs:
         # For debugging.
         kubectl get pods --all-namespaces
 
+        echo "===================== Pod Logs ============================="
+        namespace=knative-eventing
+        for pod in $(kubectl get pod -n $namespace | awk '{print $1}'); do
+          for container in $(kubectl get pod "${pod}" -n $namespace -ojsonpath='{.spec.containers[*].name}'); do
+            echo "Namespace, Pod, Container: ${namespace}, ${pod}, ${container}"
+            kubectl logs -n $namespace "${pod}" -c "${container}" || true
+            echo "----------------------------------------------------------"
+            echo "Namespace, Pod, Container (Previous instance): ${namespace}, ${pod}, ${container}"
+            kubectl logs -p -n $namespace "${pod}" -c "${container}" || true
+            echo "============================================================"
+          done
+        done
+
     - name: Run e2e Tests
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       run: |
@@ -144,7 +157,7 @@ jobs:
 
         echo "===================== Pod Logs ============================="
         namespace=knative-eventing
-        for pod in $(kubectl get pod -n $namespace | grep Running | awk '{print $1}'); do
+        for pod in $(kubectl get pod -n $namespace | awk '{print $1}'); do
           for container in $(kubectl get pod "${pod}" -n $namespace -ojsonpath='{.spec.containers[*].name}'); do
             echo "Namespace, Pod, Container: ${namespace}, ${pod}, ${container}"
             kubectl logs -n $namespace "${pod}" -c "${container}" || true

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -78,7 +78,7 @@ jobs:
       run: |
         set -x
 
-        kubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/download/0.48.0/cluster-operator.yml
+        kubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/download/0.46.0/cluster-operator.yml
 
     - name: Install Knative Eventing
       run: |

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -11,6 +11,27 @@ jobs:
   ko-resolve:
     name: e2e tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Keep running if one leg fails.
+      matrix:
+        k8s-version:
+        - v1.17.11
+        - v1.18.8
+        - v1.19.1
+
+        # Map between K8s and KinD versions.
+        # This is attempting to make it a bit clearer what's being tested.
+        # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
+        include:
+        - k8s-version: v1.17.11
+          kind-version: v0.9.0
+          kind-image-sha: sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555
+        - k8s-version: v1.18.8
+          kind-version: v0.9.0
+          kind-image-sha: sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
+        - k8s-version: v1.19.1
+          kind-version: v0.9.0
+          kind-image-sha: sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
     env:
       GOPATH: ${{ github.workspace }}
       GO111MODULE: off
@@ -38,14 +59,12 @@ jobs:
       run: |
         set -x
 
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${{ matrix.kind-version }}/kind-$(uname)-amd64
         chmod +x ./kind
         sudo mv kind /usr/local/bin
 
     - name: Create KinD Cluster
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}
-      env:
-        NODE_IMAGE: 'kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765'
       run: |
         set -x
 
@@ -53,12 +72,9 @@ jobs:
         cat > kind.yaml <<EOF
         apiVersion: kind.x-k8s.io/v1alpha4
         kind: Cluster
-        nodes:
-        - role: control-plane
-          image: ${NODE_IMAGE}
-        - role: worker
-          image: ${NODE_IMAGE}
 
+        # This is needed in order to support projected volumes with service account tokens.
+        # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
         kubeadmConfigPatches:
           - |
             apiVersion: kubeadm.k8s.io/v1beta2
@@ -69,6 +85,12 @@ jobs:
               extraArgs:
                 "service-account-issuer": "kubernetes.default.svc"
                 "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+        nodes:
+        - role: control-plane
+          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
+        - role: worker
+          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
+
         EOF
 
         # Create a cluster!

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -139,19 +139,6 @@ jobs:
         # For debugging.
         kubectl get pods --all-namespaces
 
-        echo "===================== Pod Logs ============================="
-        namespace=knative-eventing
-        for pod in $(kubectl get pod -n $namespace | awk '{print $1}'); do
-          for container in $(kubectl get pod "${pod}" -n $namespace -ojsonpath='{.spec.containers[*].name}'); do
-            echo "Namespace, Pod, Container: ${namespace}, ${pod}, ${container}"
-            kubectl logs -n $namespace "${pod}" -c "${container}" || true
-            echo "----------------------------------------------------------"
-            echo "Namespace, Pod, Container (Previous instance): ${namespace}, ${pod}, ${container}"
-            kubectl logs -p -n $namespace "${pod}" -c "${container}" || true
-            echo "============================================================"
-          done
-        done
-
     - name: Run e2e Tests
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       run: |

--- a/test/kind/prerequisites.sh
+++ b/test/kind/prerequisites.sh
@@ -27,7 +27,7 @@ pwd
 
 echo "Installing RabbitMQ Cluster Operator"
 
-kubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/download/0.48.0/cluster-operator.yml
+kubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/download/0.46.0/cluster-operator.yml
 
 echo "Installing Knative Eventing"
 

--- a/test/kind/prerequisites.sh
+++ b/test/kind/prerequisites.sh
@@ -27,10 +27,10 @@ pwd
 
 echo "Installing RabbitMQ Cluster Operator"
 
-kubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/download/0.46.0/cluster-operator.yml
+kubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/download/0.48.0/cluster-operator.yml
 
 echo "Installing Knative Eventing"
 
-kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.17.0/eventing-crds.yaml
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.18.4/eventing-crds.yaml
 sleep 2 # Wait for the CRDs to be reconciled.
-kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.17.0/eventing-core.yaml
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.18.4/eventing-core.yaml


### PR DESCRIPTION
Fix #153 by picking up a version of eventing that should have a fix for the webhook entering crashloops.

Also test with k8s 17, 18, and 19.