### PR TITLE
add e2e tests do not always json encode input

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -122,7 +122,7 @@ jobs:
         sleep 2 # Wait for the CRDs to be reconciled.
         kubectl apply --filename https://github.com/knative/eventing/releases/download/${{ matrix.eventing-version }}/eventing-core.yaml
 
-    - name: Install
+    - name: Install Broker
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       run: |
         set -x
@@ -130,6 +130,15 @@ jobs:
 
         # Install Broker.
         ko apply -f ./config/broker/
+
+    - name: Install Source
+      working-directory: ./src/knative.dev/${{ github.event.repository.name }}
+      run: |
+        set -x
+        # TODO: this should use the release script and then apply the newly created release yaml in the future.
+
+        # Install Source.
+        ko apply -f ./config/source/
 
 # todo: skip the quacken at the moment.
 #  - name: Release the Quacken

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -423,40 +423,6 @@ func TestAdapter_ConsumeMessages(t *testing.T) {
 	}
 }
 
-func TestAdapter_JsonEncode(t *testing.T) {
-	statsReporter, _ := source.NewStatsReporter()
-
-	a := &Adapter{
-		config: &adapterConfig{
-			Topic:   "",
-			Brokers: "amqp://localhost:5672/%2f",
-			ExchangeConfig: ExchangeConfig{
-				TypeOf:      "direct",
-				Durable:     true,
-				AutoDeleted: false,
-				Internal:    false,
-				NoWait:      false,
-			},
-			QueueConfig: QueueConfig{
-				Name:             "",
-				Durable:          false,
-				DeleteWhenUnused: false,
-				Exclusive:        true,
-				NoWait:           false,
-			},
-		},
-		logger:   zap.NewNop(),
-		reporter: statsReporter,
-	}
-	data, err := a.JsonEncode([]byte(`{"Test":"json"}`))
-	if err != nil {
-		t.Errorf("JsonEncode failed: %s", err)
-	}
-	if data == nil {
-		t.Errorf("Json decoded incorrectly")
-	}
-}
-
 type fakeHandler struct {
 	body   []byte
 	header http.Header

--- a/test/e2e/cmd/rabbitproducer/main.go
+++ b/test/e2e/cmd/rabbitproducer/main.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/streadway/amqp"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+type envConfig struct {
+	Username string `envconfig:"USER" required:"true"`
+	Password string `envconfig:"PASSWORD" required:"true"`
+	Broker   string `envconfig:"RABBITBROKER" required:"true"`
+	Count    int    `envconfig:"COUNT" default:"1"`
+}
+
+func failOnError(err error, msg string) {
+	if err != nil {
+		log.Fatalf("%s: %s", msg, err)
+	}
+}
+
+func main() {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		log.Fatal("[ERROR] Failed to process env var: ", err)
+		os.Exit(1)
+	}
+	connStr := fmt.Sprintf("amqp://%s:%s@%s", env.Username, env.Password, env.Broker)
+	log.Printf("Using connection String: %q", connStr)
+
+	conn, err := amqp.Dial(connStr)
+	failOnError(err, "Failed to connect to RabbitMQ")
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	failOnError(err, "Failed to open a channel")
+	defer ch.Close()
+
+	err = ch.ExchangeDeclare(
+		"logs",   // name
+		"fanout", // type
+		true,     // durable
+		false,    // auto-deleted
+		false,    // internal
+		false,    // no-wait
+		nil,      // arguments
+	)
+	failOnError(err, "Failed to declare an exchange")
+
+	for i := 0; i < env.Count; i++ {
+		body := fmt.Sprintf(`{ "id": %d, "message": "Hello, World!" }`, i)
+		err = ch.Publish(
+			"logs", // exchange
+			"",     // routing key
+			false,  // mandatory
+			false,  // immediate
+			amqp.Publishing{
+				ContentType: "text/plain",
+				Body:        []byte(body),
+			})
+		failOnError(err, "Failed to publish a message")
+		log.Printf(" [x] Sent %s", body)
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/test/e2e/config/source/rabbitmq-source.yaml
+++ b/test/e2e/config/source/rabbitmq-source.yaml
@@ -1,0 +1,34 @@
+apiVersion: sources.knative.dev/v1alpha1
+kind: RabbitmqSource
+metadata:
+  name: rabbitmq-source
+  namespace: {{ .namespace }}
+spec:
+  brokers: "rabbitmqc.{{ .namespace }}:5672/"
+  topic: ""
+  user:
+    secretKeyRef:
+      name: "rabbitmqc-default-user"
+      key: "username"
+  password:
+    secretKeyRef:
+      name: "rabbitmqc-default-user"
+      key: "password"
+  exchange_config:
+    type: "fanout"
+    durable: true
+    auto_deleted: false
+    internal: false
+    nowait: false
+  queue_config:
+    name: ""
+    routing_key: ""
+    durable: false
+    delete_when_unused: false
+    exclusive: false
+    nowait: false
+  sink:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: recorder

--- a/test/e2e/config/source/source.go
+++ b/test/e2e/config/source/source.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"context"
+	"testing"
+
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+func init() {
+	environment.RegisterPackage(manifest.ImagesLocalYaml()...)
+}
+
+func Install() feature.StepFn {
+	return func(ctx context.Context, t *testing.T) {
+		if _, err := manifest.InstallLocalYaml(ctx, map[string]interface{}{"producerCount": 5}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/test/e2e/config/sourceproducer/producer.yaml
+++ b/test/e2e/config/sourceproducer/producer.yaml
@@ -1,0 +1,40 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: producer
+  namespace: {{ .namespace }}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: producer
+      image: ko://knative.dev/eventing-rabbitmq/test/e2e/cmd/rabbitproducer
+      env:
+        - name: COUNT
+          value: '{{ .producerCount }}'
+        - name: USER
+          valueFrom:
+            secretKeyRef:
+              name: rabbitmqc-default-user
+              key: username
+        - name: PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: rabbitmqc-default-user
+              key: password
+        - name: RABBITBROKER
+          value: rabbitmqc.{{ .namespace }}.svc.cluster.local:5672
+

--- a/test/e2e/config/sourceproducer/sourceproducer.go
+++ b/test/e2e/config/sourceproducer/sourceproducer.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sourceproducer
+
+import (
+	"context"
+	"testing"
+
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+func init() {
+	environment.RegisterPackage(manifest.ImagesLocalYaml()...)
+}
+
+func Install() feature.StepFn {
+	return func(ctx context.Context, t *testing.T) {
+		if _, err := manifest.InstallLocalYaml(ctx, map[string]interface{}{"producerCount": 5}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -116,3 +116,12 @@ func TestBrokerDLQ(t *testing.T) {
 	env.Test(ctx, t, BrokerDLQTest())
 	env.Finish()
 }
+
+// TestSourceDirect makes sure a source delivers events to Sink.
+func TestSourceDirect(t *testing.T) {
+	t.Parallel()
+	ctx, env := global.Environment()
+	env.Test(ctx, t, RabbitMQCluster())
+	env.Test(ctx, t, DirectTestSource())
+	env.Finish()
+}

--- a/test/e2e/source_test.go
+++ b/test/e2e/source_test.go
@@ -1,0 +1,92 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"knative.dev/eventing-rabbitmq/test/e2e/config/recorder"
+	"knative.dev/eventing-rabbitmq/test/e2e/config/source"
+	"knative.dev/eventing-rabbitmq/test/e2e/config/sourceproducer"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
+
+	"knative.dev/eventing/pkg/test/observer"
+	recorder_collector "knative.dev/eventing/pkg/test/observer/recorder-collector"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "knative.dev/pkg/system/testing"
+)
+
+//
+// producer ---> rabbitmq --[source]--> recorder
+//
+
+// DirectTestSource makes sure an RabbitMQ Source delivers events to a sink.
+func DirectTestSource() *feature.Feature {
+	f := new(feature.Feature)
+
+	f.Setup("install test resources", source.Install())
+	f.Setup("install recorder", recorder.Install())
+	f.Alpha("RabbitMQ broker").Must("goes ready", AllGoReady)
+	f.Setup("install producer", sourceproducer.Install())
+	f.Alpha("RabbitMQ broker").Must("goes ready", CheckDirectSinkEvents)
+	return f
+}
+
+func CheckDirectSinkEvents(ctx context.Context, t *testing.T) {
+	env := environment.FromContext(ctx)
+
+	sendCount := 5
+	// TODO: we want a wait for events for x time in the future.
+	time.Sleep(1 * time.Minute)
+
+	c := recorder_collector.New(ctx)
+
+	from := duckv1.KReference{
+		Kind:       "Namespace",
+		Name:       "default",
+		APIVersion: "v1",
+	}
+
+	obsName := "recorder-" + env.Namespace()
+	events, err := c.List(ctx, from, func(ob observer.Observed) bool {
+		return ob.Observer == obsName
+	})
+	if err != nil {
+		t.Fatal("failed to list observed events, ", err)
+	}
+
+	for i, e := range events {
+		fmt.Printf("[%d]: seen by %q\n%s\n", i, e.Observer, e.Event)
+	}
+
+	got := len(events)
+	want := sendCount
+	if want != got {
+		t.Errorf("failed to observe the correct number of events, want: %d, got: %d", want, got)
+	}
+
+	// Pass!
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Add e2e tests for source using Kind

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Add e2e tests for source using Kind
- :bug: Do not always try to json encode the input
- :broom: Update outdated documentation, about install, etc.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
