### PR TITLE
fix codeowners to be single line

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,2 @@
 # Default owners are TOC, release leads and Eventing writers
-* @knative-sandbox/technical-oversight-committee
-* @knative-sandbox/knative-release-leads
-* @knative-sandbox/eventing-writers
-* @knative-sandbox/eventing-rabbitmq-approvers
-
-# hack and test are owned by productivity
-/hack/* @knative-sandbox/productivity-wg-leads
-/test/* @knative-sandbox/productivity-wg-leads
+* @knative-sandbox/technical-oversight-committee @knative-sandbox/knative-release-leads @knative-sandbox/eventing-writers @knative-sandbox/eventing-rabbitmq-approvers


### PR DESCRIPTION
see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax