### PR TITLE
Bump to go 1.16

### DIFF
--- a/.github/workflows/kind-conformance.yaml
+++ b/.github/workflows/kind-conformance.yaml
@@ -71,10 +71,10 @@ jobs:
           echo "MILESTONE_EVENTS_TARGET=${{ github.event.inputs.milestoneEventsTarget }}" >> $GITHUB_ENV
         fi
 
-    - name: Set up Go 1.15.x
+    - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.16.x
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -65,10 +65,10 @@ jobs:
           echo "SLACK_WEBHOOK=exists" >> $GITHUB_ENV
         fi
 
-    - name: Set up Go 1.15.x
+    - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.16.x
 
     - name: Install Dependencies
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/eventing-rabbitmq
 
-go 1.15
+go 1.16
 
 require (
 	github.com/NeowayLabs/wabbit v0.0.0-20200409220312-12e68ab5b0c6


### PR DESCRIPTION
The reconciler-test package is moving to rely on the [1.16 embed package](https://golang.org/pkg/embed/), so we'll need to update to bring in those changes.

## Proposed Changes

- :broom: Update go to 1.16

xref
https://github.com/knative-sandbox/reconciler-test/pull/196
https://github.com/knative-sandbox/.github/pull/108