### PR TITLE
Rabbitmq resource naming

### DIFF
--- a/.github/workflows/kind-conformance-standalone.yaml
+++ b/.github/workflows/kind-conformance-standalone.yaml
@@ -165,7 +165,7 @@ jobs:
         export BROKER_TEMPLATES=${PWD}/test/conformance/testdata/with-secret
         export BROKER_CLASS=RabbitMQBroker
         
-        SYSTEM_NAMESPACE=knative-eventing go test -v -count=1  -parallel=12 -timeout=30m -tags=e2e -run TestBrokerConformance ./test/conformance/...
+        SYSTEM_NAMESPACE=knative-eventing go test -v -count=1  -parallel=12 -timeout=20m -tags=e2e -run TestBrokerConformance ./test/conformance/...
 
     - name: Gather Failure Data
       if: ${{ failure() }}

--- a/.github/workflows/kind-conformance-standalone.yaml
+++ b/.github/workflows/kind-conformance-standalone.yaml
@@ -165,7 +165,7 @@ jobs:
         export BROKER_TEMPLATES=${PWD}/test/conformance/testdata/with-secret
         export BROKER_CLASS=RabbitMQBroker
         
-        SYSTEM_NAMESPACE=knative-eventing go test -v -count=1  -parallel=12 -timeout=20m -tags=e2e -run TestBrokerConformance ./test/conformance/...
+        SYSTEM_NAMESPACE=knative-eventing go test -v -count=1  -parallel=12 -timeout=30m -tags=e2e -run TestBrokerConformance ./test/conformance/...
 
     - name: Gather Failure Data
       if: ${{ failure() }}

--- a/pkg/rabbitmqnaming/naming.go
+++ b/pkg/rabbitmqnaming/naming.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package naming
+
+import (
+	"fmt"
+
+	"knative.dev/pkg/kmeta"
+
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+)
+
+// BrokerExchangeName constructs a name given a Broker.
+// Format is broker.Namespace.Name.BrokerUID for normal exchanges and
+// broker.Namespace.Name.dlx.BrokerUID for DLX exchanges.
+func BrokerExchangeName(b *eventingv1.Broker, dlx bool) string {
+	var exchangeBase string
+	if dlx {
+		exchangeBase = fmt.Sprintf("b.%s.%s.dlx.", b.Namespace, b.Name)
+	} else {
+		exchangeBase = fmt.Sprintf("b.%s.%s.", b.Namespace, b.Name)
+
+	}
+	return kmeta.ChildName(exchangeBase, string(b.GetUID()))
+}
+
+// TriggerDLXExchangeName constructs a name given a Broker.
+// Format is trigger.Namespace.Name.dlx.BrokerUID
+func TriggerDLXExchangeName(t *eventingv1.Trigger) string {
+	exchangeBase := fmt.Sprintf("t.%s.%s.dlx.", t.Namespace, t.Name)
+	return kmeta.ChildName(exchangeBase, string(t.GetUID()))
+}
+
+func CreateBrokerDeadLetterQueueName(b *eventingv1.Broker) string {
+	dlqBase := fmt.Sprintf("b.%s.%s.dlq.", b.Namespace, b.Name)
+	return kmeta.ChildName(dlqBase, string(b.GetUID()))
+}
+
+func CreateTriggerQueueName(t *eventingv1.Trigger) string {
+	triggerQueueBase := fmt.Sprintf("t.%s.%s.", t.Namespace, t.Name)
+	return kmeta.ChildName(triggerQueueBase, string(t.GetUID()))
+}
+
+func CreateTriggerDeadLetterQueueName(t *eventingv1.Trigger) string {
+	// TODO(vaikas): https://github.com/knative-sandbox/eventing-rabbitmq/issues/61
+	// return fmt.Sprintf("%s/%s", t.Namespace, t.Name)
+	triggerDLQBase := fmt.Sprintf("t.%s.%s.dlq.", t.Namespace, t.Name)
+	return kmeta.ChildName(triggerDLQBase, string(t.GetUID()))
+}

--- a/pkg/rabbitmqnaming/naming.go
+++ b/pkg/rabbitmqnaming/naming.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
-// BrokerExchangeName constructs a name given a Broker.
+// BrokerExchangeName creates a name for Broker Exchange.
 // Format is broker.Namespace.Name.BrokerUID for normal exchanges and
 // broker.Namespace.Name.dlx.BrokerUID for DLX exchanges.
 func BrokerExchangeName(b *eventingv1.Broker, dlx bool) string {
@@ -38,26 +38,32 @@ func BrokerExchangeName(b *eventingv1.Broker, dlx bool) string {
 	return kmeta.ChildName(exchangeBase, string(b.GetUID()))
 }
 
-// TriggerDLXExchangeName constructs a name given a Broker.
-// Format is trigger.Namespace.Name.dlx.BrokerUID
+// TriggerDLXExchangeName creates a DLX name that's used if Trigger has defined
+// DeadLetterSink.
+// Format is t.Namespace.Name.dlx.TriggerUID
 func TriggerDLXExchangeName(t *eventingv1.Trigger) string {
 	exchangeBase := fmt.Sprintf("t.%s.%s.dlx.", t.Namespace, t.Name)
 	return kmeta.ChildName(exchangeBase, string(t.GetUID()))
 }
 
+// CreateBrokerDeadLetterQueueName constructs a Broker dead letter queue name.
+// Format is b.Namespace.Name.dlq.BrokerUID
 func CreateBrokerDeadLetterQueueName(b *eventingv1.Broker) string {
 	dlqBase := fmt.Sprintf("b.%s.%s.dlq.", b.Namespace, b.Name)
 	return kmeta.ChildName(dlqBase, string(b.GetUID()))
 }
 
+// CreateTriggerQueueName creates a queue name for Trigger events.
+// Format is t.Namespace.Name.TriggerUID
 func CreateTriggerQueueName(t *eventingv1.Trigger) string {
 	triggerQueueBase := fmt.Sprintf("t.%s.%s.", t.Namespace, t.Name)
 	return kmeta.ChildName(triggerQueueBase, string(t.GetUID()))
 }
 
+// CreateTriggerDeadLetterQueueName creates a dead letter queue name for Trigger
+// if Trigger has defined a DeadLetterSink.
+// Format is t.Namespace.Name.dlq.TriggerUID
 func CreateTriggerDeadLetterQueueName(t *eventingv1.Trigger) string {
-	// TODO(vaikas): https://github.com/knative-sandbox/eventing-rabbitmq/issues/61
-	// return fmt.Sprintf("%s/%s", t.Namespace, t.Name)
 	triggerDLQBase := fmt.Sprintf("t.%s.%s.dlq.", t.Namespace, t.Name)
 	return kmeta.ChildName(triggerDLQBase, string(t.GetUID()))
 }

--- a/pkg/rabbitmqnaming/naming_test.go
+++ b/pkg/rabbitmqnaming/naming_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package naming
 
 import (

--- a/pkg/rabbitmqnaming/naming_test.go
+++ b/pkg/rabbitmqnaming/naming_test.go
@@ -1,0 +1,98 @@
+package naming
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+)
+
+const (
+	brokerName      = "testbroker"
+	brokerUID       = "brokeruid"
+	triggerName     = "testtrigger"
+	triggerUID      = "triggeruid"
+	namespace       = "foobar"
+	rabbitmqcluster = "testrabbitmqcluster"
+)
+
+func TestExchangeName(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		namespace string
+		dlx       bool
+		want      string
+	}{{
+		name:      brokerName,
+		namespace: namespace,
+		want:      "b.foobar.testbroker.brokeruid",
+	}, {
+		name:      brokerName,
+		namespace: namespace,
+		want:      "b.foobar.testbroker.dlx.brokeruid",
+		dlx:       true,
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BrokerExchangeName(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{UID: brokerUID, Namespace: tt.namespace, Name: tt.name}}, tt.dlx)
+			if got != tt.want {
+				t.Errorf("Unexpected name for Broker Exchange %s/%s DLX: %t: want:\n%+s\ngot:\n%+s", tt.namespace, tt.name, tt.dlx, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestTriggerDLXExchangeName(t *testing.T) {
+	want := "t.foobar.testtrigger.dlx.triggeruid"
+	got := TriggerDLXExchangeName(&eventingv1.Trigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      triggerName,
+			UID:       triggerUID,
+		},
+	})
+	if want != got {
+		t.Errorf("Unexpected name for foobar/testtrigger Trigger DLX: want:\n%q\ngot:\n%q", want, got)
+	}
+}
+
+func TestCreateBrokerDeadLetterQueueName(t *testing.T) {
+	want := "b.foobar.testbroker.dlq.brokeruid"
+	got := CreateBrokerDeadLetterQueueName(&eventingv1.Broker{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      brokerName,
+			UID:       brokerUID,
+		},
+	})
+	if want != got {
+		t.Errorf("Unexpected name for foobar/testbroker Broker DLQ: want:\n%q\ngot:\n%q", want, got)
+	}
+}
+
+func TestCreateTriggerQueueName(t *testing.T) {
+	want := "t.foobar.testtrigger.triggeruid"
+	got := CreateTriggerQueueName(&eventingv1.Trigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      triggerName,
+			UID:       triggerUID,
+		},
+	})
+	if want != got {
+		t.Errorf("Unexpected name for foobar/testtrigger Queue: want:\n%q\ngot:\n%q", want, got)
+	}
+}
+
+func TestCreateTriggerDeadLetterQueueName(t *testing.T) {
+	want := "t.foobar.testtrigger.dlq.triggeruid"
+	got := CreateTriggerDeadLetterQueueName(&eventingv1.Trigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      triggerName,
+			UID:       triggerUID,
+		},
+	})
+	if want != got {
+		t.Errorf("Unexpected name for foobar/trigger Trigger DLQ: want:\n%q\ngot:\n%q", want, got)
+	}
+}

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -69,6 +69,7 @@ const (
 	brokerClass = "RabbitMQBroker"
 	testNS      = "test-namespace"
 	brokerName  = "test-broker"
+	brokerUID   = "broker-test-uid"
 
 	rabbitSecretName          = "test-secret"
 	rabbitBrokerSecretName    = "test-broker-broker-rabbit"
@@ -201,7 +202,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(invalidConfigForRabbitOperator()),
 					WithInitBrokerConditions),
@@ -209,7 +210,7 @@ func TestReconcile(t *testing.T) {
 			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(invalidConfigForRabbitOperator()),
@@ -223,7 +224,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -232,7 +233,7 @@ func TestReconcile(t *testing.T) {
 			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -246,7 +247,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -255,7 +256,7 @@ func TestReconcile(t *testing.T) {
 			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -269,7 +270,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -278,7 +279,7 @@ func TestReconcile(t *testing.T) {
 			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -292,7 +293,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -302,7 +303,7 @@ func TestReconcile(t *testing.T) {
 			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -316,7 +317,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -326,7 +327,7 @@ func TestReconcile(t *testing.T) {
 			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -340,7 +341,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -356,11 +357,11 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
-					WithExchangeFailed("ExchangeFailure", `Failed to reconcile exchange "broker.test-namespace.test-broker": inducing failure for create exchanges`)),
+					WithExchangeFailed("ExchangeFailure", `Failed to reconcile exchange "b.test-namespace.test-broker.broker-test-uid": inducing failure for create exchanges`)),
 			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeWarning, "InternalError", `inducing failure for create exchanges`),
@@ -370,7 +371,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -382,18 +383,18 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
-					WithExchangeFailed("ExchangeFailure", `exchange "broker.test-namespace.test-broker" is not ready`)),
+					WithExchangeFailed("ExchangeFailure", `exchange "b.test-namespace.test-broker.broker-test-uid" is not ready`)),
 			}},
 		}, {
 			Name: "Exchange exists, create DLX CRD, not ready",
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -406,18 +407,18 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
-					WithExchangeFailed("ExchangeFailure", `DLX exchange "broker.test-namespace.test-broker.dlx" is not ready`)),
+					WithExchangeFailed("ExchangeFailure", `DLX exchange "b.test-namespace.test-broker.dlx.broker-test-uid" is not ready`)),
 			}},
 		}, {
 			Name: "Exchange exists, create DLX exchange fails",
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -434,11 +435,11 @@ func TestReconcile(t *testing.T) {
 			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
-					WithExchangeFailed("ExchangeFailure", `Failed to reconcile DLX exchange "broker.test-namespace.test-broker.dlx": inducing failure for create exchanges`)),
+					WithExchangeFailed("ExchangeFailure", `Failed to reconcile DLX exchange "b.test-namespace.test-broker.dlx.broker-test-uid": inducing failure for create exchanges`)),
 			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeWarning, "InternalError", `inducing failure for create exchanges`),
@@ -448,7 +449,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -466,12 +467,12 @@ func TestReconcile(t *testing.T) {
 			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
 					WithExchangeReady(),
-					WithDLXFailed("QueueFailure", `Failed to reconcile Dead Letter Queue "broker.test-namespace.test-broker.dlq" : inducing failure for create queues`)),
+					WithDLXFailed("QueueFailure", `Failed to reconcile Dead Letter Queue "b.test-namespace.test-broker.dlq.broker-test-uid" : inducing failure for create queues`)),
 			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeWarning, "InternalError", `inducing failure for create queues`),
@@ -481,7 +482,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -495,19 +496,19 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
 					WithExchangeReady(),
-					WithDLXFailed("QueueFailure", `Dead Letter Queue "broker.test-namespace.test-broker.dlq" is not ready`)),
+					WithDLXFailed("QueueFailure", `Dead Letter Queue "b.test-namespace.test-broker.dlq.broker-test-uid" is not ready`)),
 			}},
 		}, {
 			Name: "Both exchanges exist, queue exists, creates binding CRD",
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -522,20 +523,20 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
 					WithExchangeReady(),
 					WithDLXReady(),
-					WithDeadLetterSinkFailed("DLQ binding", `DLQ binding "broker.test-namespace.test-broker.dlq" is not ready`)),
+					WithDeadLetterSinkFailed("DLQ binding", `DLQ binding "b.test-namespace.test-broker.dlq.broker-test-uid" is not ready`)),
 			}},
 		}, {
 			Name: "Both exchanges exist, queue exists, create binding CRD fails",
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -554,13 +555,13 @@ func TestReconcile(t *testing.T) {
 			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerUID("uid-for-test"),
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
 					WithExchangeReady(),
 					WithDLXReady(),
-					WithDeadLetterSinkFailed("DLQ binding", `Failed to reconcile DLQ binding "broker.test-namespace.test-broker.dlq" : inducing failure for create bindings`)),
+					WithDeadLetterSinkFailed("DLQ binding", `Failed to reconcile DLQ binding "b.test-namespace.test-broker.dlq.broker-test-uid" : inducing failure for create bindings`)),
 			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeWarning, "InternalError", `inducing failure for create bindings`),
@@ -570,6 +571,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -587,6 +589,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -605,6 +608,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -625,6 +629,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -640,6 +645,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -658,6 +664,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -678,6 +685,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -697,6 +705,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -717,6 +726,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -737,6 +747,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -758,6 +769,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -778,6 +790,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -799,6 +812,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -819,6 +833,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -840,6 +855,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -861,6 +877,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -882,6 +899,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithBrokerDelivery(delivery),
@@ -900,6 +918,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -921,6 +940,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithBrokerDelivery(deliveryUnresolvableDeadLetterSink),
@@ -940,6 +960,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -1021,6 +1042,7 @@ func createBrokerSecret(data string) *corev1.Secret {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Broker",
 				Name:               brokerName,
+				UID:                brokerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -1056,6 +1078,7 @@ func createSecretForRabbitmqCluster() *corev1.Secret {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Broker",
 				Name:               brokerName,
+				UID:                brokerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -1078,6 +1101,7 @@ func createSecretForRabbitmqClusterNoUser() *corev1.Secret {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Broker",
 				Name:               brokerName,
+				UID:                brokerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -1099,6 +1123,7 @@ func createSecretForRabbitmqClusterNoPassword() *corev1.Secret {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Broker",
 				Name:               brokerName,
+				UID:                brokerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -1111,7 +1136,7 @@ func createSecretForRabbitmqClusterNoPassword() *corev1.Secret {
 
 func createIngressDeployment() *appsv1.Deployment {
 	args := &resources.IngressArgs{
-		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS}},
+		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS, UID: brokerUID}},
 		Image:              ingressImage,
 		RabbitMQSecretName: rabbitBrokerSecretName,
 		BrokerUrlSecretKey: resources.BrokerURLSecretKey,
@@ -1121,7 +1146,7 @@ func createIngressDeployment() *appsv1.Deployment {
 
 func createDifferentIngressDeployment() *appsv1.Deployment {
 	args := &resources.IngressArgs{
-		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS}},
+		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS, UID: brokerUID}},
 		Image:              "differentImage",
 		RabbitMQSecretName: rabbitBrokerSecretName,
 		BrokerUrlSecretKey: resources.BrokerURLSecretKey,
@@ -1130,11 +1155,11 @@ func createDifferentIngressDeployment() *appsv1.Deployment {
 }
 
 func createIngressService() *corev1.Service {
-	return resources.MakeIngressService(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS}})
+	return resources.MakeIngressService(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS, UID: brokerUID}})
 }
 
 func createDifferentIngressService() *corev1.Service {
-	svc := resources.MakeIngressService(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS}})
+	svc := resources.MakeIngressService(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS, UID: brokerUID}})
 	svc.Spec.Ports = []corev1.ServicePort{{Name: "diff", Port: 9999}}
 	return svc
 }
@@ -1170,6 +1195,7 @@ func createDispatcherDeployment() *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      brokerName,
 			Namespace: testNS,
+			UID:       brokerUID,
 		},
 		Spec: eventingv1.BrokerSpec{
 			Config:   config(),
@@ -1180,7 +1206,7 @@ func createDispatcherDeployment() *appsv1.Deployment {
 		Broker:             broker,
 		Image:              dispatcherImage,
 		RabbitMQSecretName: rabbitBrokerSecretName,
-		QueueName:          "broker.test-namespace.test-broker.dlq",
+		QueueName:          "b.test-namespace.test-broker.dlq.broker-test-uid",
 		BrokerUrlSecretKey: "brokerURL",
 		BrokerIngressURL:   brokerAddress,
 		Subscriber:         deadLetterSinkAddress,
@@ -1193,14 +1219,14 @@ func createExchange(dlx bool) *rabbitv1beta1.Exchange {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      brokerName,
 			Namespace: testNS,
-			UID:       "uid-for-test",
+			UID:       brokerUID,
 		},
 	}
 	var exchangeName string
 	if dlx {
-		exchangeName = fmt.Sprintf("broker.%s.%s.dlx", testNS, brokerName)
+		exchangeName = fmt.Sprintf("b.%s.%s.dlx.%s", testNS, brokerName, brokerUID)
 	} else {
-		exchangeName = fmt.Sprintf("broker.%s.%s", testNS, brokerName)
+		exchangeName = fmt.Sprintf("b.%s.%s.%s", testNS, brokerName, brokerUID)
 	}
 
 	return &rabbitv1beta1.Exchange{
@@ -1244,14 +1270,14 @@ func createQueue(dlx bool) *rabbitv1beta1.Queue {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      brokerName,
 			Namespace: testNS,
-			UID:       "uid-for-test",
+			UID:       brokerUID,
 		},
 	}
 	var queueName string
 	if dlx {
-		queueName = fmt.Sprintf("broker.%s.%s.dlq", testNS, brokerName)
+		queueName = fmt.Sprintf("b.%s.%s.dlq.broker-test-uid", testNS, brokerName)
 	} else {
-		queueName = fmt.Sprintf("broker.%s.%s", testNS, brokerName)
+		queueName = fmt.Sprintf("b.%s.%s.broker-test-uid", testNS, brokerName)
 	}
 
 	return &rabbitv1beta1.Queue{
@@ -1291,14 +1317,14 @@ func createBinding(dlx bool) *rabbitv1beta1.Binding {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      brokerName,
 			Namespace: testNS,
-			UID:       "uid-for-test",
+			UID:       brokerUID,
 		},
 	}
 	var bindingName string
 	if dlx {
-		bindingName = fmt.Sprintf("broker.%s.%s.dlq", testNS, brokerName)
+		bindingName = fmt.Sprintf("b.%s.%s.dlq.broker-test-uid", testNS, brokerName)
 	} else {
-		bindingName = fmt.Sprintf("broker.%s.%s", testNS, brokerName)
+		bindingName = fmt.Sprintf("b.%s.%s.broker-test-uid", testNS, brokerName)
 	}
 
 	return &rabbitv1beta1.Binding{
@@ -1314,7 +1340,7 @@ func createBinding(dlx bool) *rabbitv1beta1.Binding {
 			Vhost:           "/",
 			DestinationType: "queue",
 			Destination:     bindingName,
-			Source:          "broker.test-namespace.test-broker.dlx",
+			Source:          "b.test-namespace.test-broker.dlx.broker-test-uid",
 			RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
 				Name: rabbitMQBrokerName,
 			},

--- a/pkg/reconciler/broker/resources/exchange_test.go
+++ b/pkg/reconciler/broker/resources/exchange_test.go
@@ -14,49 +14,12 @@ import (
 
 const (
 	brokerName      = "testbroker"
+	brokerUID       = "broker-test-uid"
 	triggerName     = "testtrigger"
+	triggerUID      = "trigger-test-uid"
 	namespace       = "foobar"
 	rabbitmqcluster = "testrabbitmqcluster"
 )
-
-func TestExchangeName(t *testing.T) {
-	for _, tt := range []struct {
-		name      string
-		namespace string
-		dlx       bool
-		want      string
-	}{{
-		name:      brokerName,
-		namespace: namespace,
-		want:      "broker.foobar.testbroker",
-	}, {
-		name:      brokerName,
-		namespace: namespace,
-		want:      "broker.foobar.testbroker.dlx",
-		dlx:       true,
-	}} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := resources.ExchangeName(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Namespace: tt.namespace, Name: tt.name}}, tt.dlx)
-			if got != tt.want {
-				t.Errorf("Unexpected name for %s/%s DLX: %t: want:\n%+s\ngot:\n%+s", tt.namespace, tt.name, tt.dlx, tt.want, got)
-			}
-		})
-	}
-}
-
-func TestTriggerDLXExchangeName(t *testing.T) {
-	want := "trigger.foobar.testtrigger.dlx"
-	got := resources.TriggerDLXExchangeName(&eventingv1.Trigger{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "foobar",
-			Name:      "testtrigger",
-		},
-	})
-	if want != got {
-		t.Errorf("Unexpected name for foobar/testtrigger Trigger DLX: want:\n%q\ngot:\n%q", want, got)
-	}
-}
 
 func TestNewExchange(t *testing.T) {
 	for _, tt := range []struct {
@@ -69,18 +32,19 @@ func TestNewExchange(t *testing.T) {
 		want: &rabbitv1beta1.Exchange{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      "broker.foobar.testbroker",
+				Name:      "b.foobar.testbroker.broker-test-uid",
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						Kind:       "Broker",
 						APIVersion: "eventing.knative.dev/v1",
 						Name:       brokerName,
+						UID:        brokerUID,
 					},
 				},
 				Labels: map[string]string{"eventing.knative.dev/broker": "testbroker"},
 			},
 			Spec: rabbitv1beta1.ExchangeSpec{
-				Name:       "broker.foobar.testbroker",
+				Name:       "b.foobar.testbroker.broker-test-uid",
 				Type:       "headers",
 				Durable:    true,
 				AutoDelete: false,
@@ -95,18 +59,19 @@ func TestNewExchange(t *testing.T) {
 		want: &rabbitv1beta1.Exchange{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      "broker.foobar.testbroker.dlx",
+				Name:      "b.foobar.testbroker.dlx.broker-test-uid",
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						Kind:       "Broker",
 						APIVersion: "eventing.knative.dev/v1",
 						Name:       brokerName,
+						UID:        brokerUID,
 					},
 				},
 				Labels: map[string]string{"eventing.knative.dev/broker": "testbroker"},
 			},
 			Spec: rabbitv1beta1.ExchangeSpec{
-				Name:       "broker.foobar.testbroker.dlx",
+				Name:       "b.foobar.testbroker.dlx.broker-test-uid",
 				Type:       "headers",
 				Durable:    true,
 				AutoDelete: false,
@@ -122,17 +87,19 @@ func TestNewExchange(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      triggerName,
+				UID:       triggerUID,
 			},
 		},
 		want: &rabbitv1beta1.Exchange{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      "trigger.foobar.testtrigger.dlx",
+				Name:      "t.foobar.testtrigger.dlx.trigger-test-uid",
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						Kind:       "Trigger",
 						APIVersion: "eventing.knative.dev/v1",
 						Name:       triggerName,
+						UID:        triggerUID,
 					},
 				},
 				Labels: map[string]string{
@@ -141,7 +108,7 @@ func TestNewExchange(t *testing.T) {
 				},
 			},
 			Spec: rabbitv1beta1.ExchangeSpec{
-				Name:       "trigger.foobar.testtrigger.dlx",
+				Name:       "t.foobar.testtrigger.dlx.trigger-test-uid",
 				Type:       "headers",
 				Durable:    true,
 				AutoDelete: false,
@@ -157,6 +124,7 @@ func TestNewExchange(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      brokerName,
 						Namespace: namespace,
+						UID:       brokerUID,
 					},
 					Spec: eventingv1.BrokerSpec{
 						Config: &duckv1.KReference{

--- a/pkg/reconciler/broker/resources/ingress.go
+++ b/pkg/reconciler/broker/resources/ingress.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	naming "knative.dev/eventing-rabbitmq/pkg/rabbitmqnaming"
 	"knative.dev/eventing/pkg/apis/eventing"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/pkg/kmeta"
@@ -92,7 +93,7 @@ func MakeIngressDeployment(args *IngressArgs) *appsv1.Deployment {
 							},
 						}, {
 							Name:  "EXCHANGE_NAME",
-							Value: ExchangeName(args.Broker, false),
+							Value: naming.BrokerExchangeName(args.Broker, false),
 						}},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8080,

--- a/pkg/reconciler/broker/resources/ingress_test.go
+++ b/pkg/reconciler/broker/resources/ingress_test.go
@@ -31,14 +31,16 @@ import (
 )
 
 const (
-	deploymentName = "testbroker-broker-ingress"
-	serviceName    = "testbroker-broker-ingress"
+	deploymentName     = "testbroker-broker-ingress"
+	serviceName        = "testbroker-broker-ingress"
+	brokerUID          = "broker-test-uid"
+	brokerExchangeName = "b.testnamespace.testbroker.broker-test-uid"
 )
 
 func TestMakeIngressDeployment(t *testing.T) {
 	var TrueValue = true
 	args := &IngressArgs{
-		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: ns}},
+		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: ns, UID: brokerUID}},
 		Image:              image,
 		RabbitMQSecretName: secretName,
 		BrokerUrlSecretKey: brokerURLKey,
@@ -53,6 +55,7 @@ func TestMakeIngressDeployment(t *testing.T) {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Broker",
 				Name:               brokerName,
+				UID:                brokerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -94,7 +97,7 @@ func TestMakeIngressDeployment(t *testing.T) {
 							},
 						}, {
 							Name:  "EXCHANGE_NAME",
-							Value: "broker." + ns + "." + brokerName,
+							Value: brokerExchangeName,
 						}},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8080,
@@ -113,7 +116,7 @@ func TestMakeIngressDeployment(t *testing.T) {
 
 func TestMakeIngressService(t *testing.T) {
 	var TrueValue = true
-	got := MakeIngressService(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: ns}})
+	got := MakeIngressService(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: ns, UID: brokerUID}})
 	want := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -126,6 +129,7 @@ func TestMakeIngressService(t *testing.T) {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Broker",
 				Name:               brokerName,
+				UID:                brokerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},

--- a/pkg/reconciler/brokerstandalone/broker.go
+++ b/pkg/reconciler/brokerstandalone/broker.go
@@ -37,6 +37,7 @@ import (
 	"knative.dev/pkg/network"
 
 	dialer "knative.dev/eventing-rabbitmq/pkg/amqp"
+	naming "knative.dev/eventing-rabbitmq/pkg/rabbitmqnaming"
 	"knative.dev/eventing-rabbitmq/pkg/reconciler/brokerstandalone/resources"
 	triggerresources "knative.dev/eventing-rabbitmq/pkg/reconciler/triggerstandalone/resources"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
@@ -169,7 +170,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, b *eventingv1.Broker) pkg
 		logging.FromContext(ctx).Errorw("Problem deleting DLX exchange", zap.Error(err))
 	}
 	queueArgs := &triggerresources.QueueArgs{
-		QueueName:   triggerresources.CreateBrokerDeadLetterQueueName(b),
+		QueueName:   naming.CreateBrokerDeadLetterQueueName(b),
 		RabbitmqURL: args.RabbitMQURL.String(),
 	}
 	err = triggerresources.DeleteQueue(r.dialerFunc, queueArgs)
@@ -276,7 +277,7 @@ func (r *Reconciler) reconcileDLXDispatcherDeployment(ctx context.Context, b *ev
 			Image:  r.dispatcherImage,
 			//ServiceAccountName string
 			RabbitMQSecretName: resources.SecretName(b.Name),
-			QueueName:          triggerresources.CreateBrokerDeadLetterQueueName(b),
+			QueueName:          naming.CreateBrokerDeadLetterQueueName(b),
 			BrokerUrlSecretKey: resources.BrokerURLSecretKey,
 			Subscriber:         sub,
 			BrokerIngressURL:   b.Status.Address.URL,
@@ -307,7 +308,7 @@ func (r *Reconciler) reconcileDLQBinding(ctx context.Context, b *eventingv1.Brok
 		RoutingKey: "",
 		BrokerURL:  args.RabbitMQURL.String(),
 		AdminURL:   r.adminURL,
-		QueueName:  triggerresources.CreateBrokerDeadLetterQueueName(b),
+		QueueName:  naming.CreateBrokerDeadLetterQueueName(b),
 	})
 	if err != nil {
 		logging.FromContext(ctx).Error("Problem declaring Broker DLQ Binding", zap.Error(err))
@@ -339,7 +340,7 @@ func (r *Reconciler) reconcileUsingLibraries(ctx context.Context, b *eventingv1.
 	}
 
 	queueArgs := &triggerresources.QueueArgs{
-		QueueName:   triggerresources.CreateBrokerDeadLetterQueueName(b),
+		QueueName:   naming.CreateBrokerDeadLetterQueueName(b),
 		RabbitmqURL: args.RabbitMQURL.String(),
 	}
 	_, err = triggerresources.DeclareQueue(r.dialerFunc, queueArgs)

--- a/pkg/reconciler/brokerstandalone/broker_test.go
+++ b/pkg/reconciler/brokerstandalone/broker_test.go
@@ -70,6 +70,7 @@ const (
 	brokerClass = "RabbitMQBroker"
 	testNS      = "test-namespace"
 	brokerName  = "test-broker"
+	brokerUID   = "broker-test-uid"
 
 	rabbitSecretName          = "test-secret"
 	rabbitBrokerSecretName    = "test-broker-broker-rabbit"
@@ -170,6 +171,7 @@ func TestReconcile(t *testing.T) {
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
 					WithBrokerClass(brokerClass),
+					WithBrokerUID(brokerUID),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions,
 					WithBrokerDeletionTimestamp),
@@ -192,6 +194,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions),
 			},
@@ -204,6 +207,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithExchangeFailed("ExchangeCredentialsUnavailable", "Failed to get arguments for creating exchange: Broker.Spec.Config is required")),
@@ -215,6 +219,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(&duckv1.KReference{Kind: "Secret", APIVersion: "v1"}),
 					WithInitBrokerConditions),
@@ -228,6 +233,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(&duckv1.KReference{Kind: "Secret", APIVersion: "v1"}),
 					WithInitBrokerConditions,
@@ -455,6 +461,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -465,6 +472,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -524,6 +532,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -535,6 +544,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -560,6 +570,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -572,6 +583,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -597,6 +609,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -609,6 +622,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -634,6 +648,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -647,6 +662,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -672,6 +688,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -679,6 +696,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -706,6 +724,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithInitBrokerConditions),
@@ -716,6 +735,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -746,7 +766,8 @@ func TestReconcile(t *testing.T) {
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithBrokerDelivery(delivery),
-					WithInitBrokerConditions),
+					WithInitBrokerConditions,
+					WithBrokerUID(brokerUID)),
 				createSecret(rabbitURL),
 				rt.NewEndpoints(ingressServiceName, testNS,
 					rt.WithEndpointsLabels(IngressLabels()),
@@ -754,6 +775,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -783,6 +805,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithBrokerConfig(config()),
 					WithBrokerDelivery(deliveryUnresolvableDeadLetterSink),
@@ -794,6 +817,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerUID(brokerUID),
 					WithBrokerClass(brokerClass),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
@@ -889,6 +913,7 @@ func createBrokerSecret(data string) *corev1.Secret {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Broker",
 				Name:               brokerName,
+				UID:                brokerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -919,6 +944,7 @@ func createSecretForRabbitmqCluster() *corev1.Secret {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Broker",
 				Name:               brokerName,
+				UID:                brokerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -941,6 +967,7 @@ func createSecretForRabbitmqClusterNoUser() *corev1.Secret {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Broker",
 				Name:               brokerName,
+				UID:                brokerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -962,6 +989,7 @@ func createSecretForRabbitmqClusterNoPassword() *corev1.Secret {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Broker",
 				Name:               brokerName,
+				UID:                brokerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -974,7 +1002,7 @@ func createSecretForRabbitmqClusterNoPassword() *corev1.Secret {
 
 func createIngressDeployment() *appsv1.Deployment {
 	args := &resources.IngressArgs{
-		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS}},
+		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS, UID: brokerUID}},
 		Image:              ingressImage,
 		RabbitMQSecretName: rabbitBrokerSecretName,
 		BrokerUrlSecretKey: resources.BrokerURLSecretKey,
@@ -984,7 +1012,7 @@ func createIngressDeployment() *appsv1.Deployment {
 
 func createDifferentIngressDeployment() *appsv1.Deployment {
 	args := &resources.IngressArgs{
-		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS}},
+		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS, UID: brokerUID}},
 		Image:              "differentImage",
 		RabbitMQSecretName: rabbitBrokerSecretName,
 		BrokerUrlSecretKey: resources.BrokerURLSecretKey,
@@ -993,11 +1021,11 @@ func createDifferentIngressDeployment() *appsv1.Deployment {
 }
 
 func createIngressService() *corev1.Service {
-	return resources.MakeIngressService(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS}})
+	return resources.MakeIngressService(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS, UID: brokerUID}})
 }
 
 func createDifferentIngressService() *corev1.Service {
-	svc := resources.MakeIngressService(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS}})
+	svc := resources.MakeIngressService(&eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: testNS, UID: brokerUID}})
 	svc.Spec.Ports = []corev1.ServicePort{{Name: "diff", Port: 9999}}
 	return svc
 }
@@ -1070,6 +1098,7 @@ func createDispatcherDeployment() *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      brokerName,
 			Namespace: testNS,
+			UID:       brokerUID,
 		},
 		Spec: eventingv1.BrokerSpec{
 			Config:   config(),
@@ -1080,7 +1109,7 @@ func createDispatcherDeployment() *appsv1.Deployment {
 		Broker:             broker,
 		Image:              dispatcherImage,
 		RabbitMQSecretName: rabbitBrokerSecretName,
-		QueueName:          "broker.test-namespace.test-broker.dlq",
+		QueueName:          "b.test-namespace.test-broker.dlq.broker-test-uid",
 		BrokerUrlSecretKey: "brokerURL",
 		BrokerIngressURL:   brokerAddress,
 		Subscriber:         deadLetterSinkAddress,

--- a/pkg/reconciler/brokerstandalone/resources/exchange.go
+++ b/pkg/reconciler/brokerstandalone/resources/exchange.go
@@ -41,6 +41,21 @@ type ExchangeArgs struct {
 	DLX bool
 }
 
+// ExchangeLabels generates the labels present on the Exchange linking the Broker to the
+// Exchange.
+func ExchangeLabels(b *eventingv1.Broker, t *eventingv1.Trigger) map[string]string {
+	if t != nil {
+		return map[string]string{
+			"eventing.knative.dev/broker":  b.Name,
+			"eventing.knative.dev/trigger": t.Name,
+		}
+	} else {
+		return map[string]string{
+			"eventing.knative.dev/broker": b.Name,
+		}
+	}
+}
+
 // DeclareExchange declares the Exchange for a Broker.
 func DeclareExchange(dialerFunc dialer.DialerFunc, args *ExchangeArgs) (*corev1.Secret, error) {
 	conn, err := dialerFunc(args.RabbitMQURL.String())

--- a/pkg/reconciler/brokerstandalone/resources/exchange.go
+++ b/pkg/reconciler/brokerstandalone/resources/exchange.go
@@ -41,21 +41,6 @@ type ExchangeArgs struct {
 	DLX bool
 }
 
-// ExchangeLabels generates the labels present on the Exchange linking the Broker to the
-// Exchange.
-func ExchangeLabels(b *eventingv1.Broker, t *eventingv1.Trigger) map[string]string {
-	if t != nil {
-		return map[string]string{
-			"eventing.knative.dev/broker":  b.Name,
-			"eventing.knative.dev/trigger": t.Name,
-		}
-	} else {
-		return map[string]string{
-			"eventing.knative.dev/broker": b.Name,
-		}
-	}
-}
-
 // DeclareExchange declares the Exchange for a Broker.
 func DeclareExchange(dialerFunc dialer.DialerFunc, args *ExchangeArgs) (*corev1.Secret, error) {
 	conn, err := dialerFunc(args.RabbitMQURL.String())

--- a/pkg/reconciler/brokerstandalone/resources/ingress.go
+++ b/pkg/reconciler/brokerstandalone/resources/ingress.go
@@ -24,6 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	naming "knative.dev/eventing-rabbitmq/pkg/rabbitmqnaming"
+
 	"knative.dev/eventing/pkg/apis/eventing"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/pkg/kmeta"
@@ -92,7 +94,7 @@ func MakeIngressDeployment(args *IngressArgs) *appsv1.Deployment {
 							},
 						}, {
 							Name:  "EXCHANGE_NAME",
-							Value: ExchangeName(args.Broker, false),
+							Value: naming.BrokerExchangeName(args.Broker, false),
 						}},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8080,

--- a/pkg/reconciler/brokerstandalone/resources/ingress_test.go
+++ b/pkg/reconciler/brokerstandalone/resources/ingress_test.go
@@ -33,12 +33,13 @@ import (
 const (
 	deploymentName = "testbroker-broker-ingress"
 	serviceName    = "testbroker-broker-ingress"
+	brokerUID      = "broker-test-uid"
 )
 
 func TestMakeIngressDeployment(t *testing.T) {
 	var TrueValue = true
 	args := &IngressArgs{
-		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: ns}},
+		Broker:             &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: ns, UID: brokerUID}},
 		Image:              image,
 		RabbitMQSecretName: secretName,
 		BrokerUrlSecretKey: brokerURLKey,
@@ -53,6 +54,7 @@ func TestMakeIngressDeployment(t *testing.T) {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Broker",
 				Name:               brokerName,
+				UID:                brokerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -94,7 +96,7 @@ func TestMakeIngressDeployment(t *testing.T) {
 							},
 						}, {
 							Name:  "EXCHANGE_NAME",
-							Value: "broker." + ns + "." + brokerName,
+							Value: "b." + ns + "." + brokerName + "." + brokerUID,
 						}},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8080,

--- a/pkg/reconciler/trigger/resources/binding.go
+++ b/pkg/reconciler/trigger/resources/binding.go
@@ -24,7 +24,7 @@ import (
 	rabbitv1beta1 "github.com/rabbitmq/messaging-topology-operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	brokerresources "knative.dev/eventing-rabbitmq/pkg/reconciler/broker/resources"
+	naming "knative.dev/eventing-rabbitmq/pkg/rabbitmqnaming"
 	"knative.dev/pkg/kmeta"
 
 	"knative.dev/eventing/pkg/apis/eventing"
@@ -51,9 +51,9 @@ func NewBinding(ctx context.Context, broker *eventingv1.Broker, trigger *eventin
 	// that we're returning.
 	if trigger != nil {
 		or = *kmeta.NewControllerRef(trigger)
-		bindingName = CreateTriggerQueueName(trigger)
+		bindingName = naming.CreateTriggerQueueName(trigger)
 		arguments[BindingKey] = trigger.Name
-		sourceName = brokerresources.ExchangeName(broker, false)
+		sourceName = naming.BrokerExchangeName(broker, false)
 		if trigger.Spec.Filter != nil && trigger.Spec.Filter.Attributes != nil {
 			for key, val := range trigger.Spec.Filter.Attributes {
 				arguments[key] = val
@@ -61,9 +61,9 @@ func NewBinding(ctx context.Context, broker *eventingv1.Broker, trigger *eventin
 		}
 	} else {
 		or = *kmeta.NewControllerRef(broker)
-		bindingName = CreateBrokerDeadLetterQueueName(broker)
+		bindingName = naming.CreateBrokerDeadLetterQueueName(broker)
 		arguments[DLQBindingKey] = broker.Name
-		sourceName = brokerresources.ExchangeName(broker, true)
+		sourceName = naming.BrokerExchangeName(broker, true)
 	}
 
 	argumentsJson, err := json.Marshal(arguments)
@@ -107,8 +107,8 @@ func NewTriggerDLQBinding(ctx context.Context, broker *eventingv1.Broker, trigge
 		TriggerDLQBindingKey: trigger.Name,
 	}
 
-	bindingName := CreateTriggerDeadLetterQueueName(trigger)
-	sourceName := brokerresources.TriggerDLXExchangeName(trigger)
+	bindingName := naming.CreateTriggerDeadLetterQueueName(trigger)
+	sourceName := naming.TriggerDLXExchangeName(trigger)
 	argumentsJson, err := json.Marshal(arguments)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode DLQ binding arguments %+v : %s", argumentsJson, err)

--- a/pkg/reconciler/trigger/resources/binding_test.go
+++ b/pkg/reconciler/trigger/resources/binding_test.go
@@ -34,6 +34,8 @@ import (
 
 const (
 	brokerName      = "testbroker"
+	brokerUID       = "broker-test-uid"
+	triggerUID      = "trigger-test-uid"
 	rabbitmqcluster = "testrabbitmqcluster"
 )
 
@@ -50,20 +52,21 @@ func TestNewBinding(t *testing.T) {
 		want: &rabbitv1beta1.Binding{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      "broker.foobar.testbroker.dlq",
+				Name:      "b.foobar.testbroker.dlq.broker-test-uid",
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						Kind:       "Broker",
 						APIVersion: "eventing.knative.dev/v1",
 						Name:       brokerName,
+						UID:        brokerUID,
 					},
 				},
 				Labels: map[string]string{"eventing.knative.dev/broker": "testbroker"},
 			},
 			Spec: rabbitv1beta1.BindingSpec{
 				Vhost:           "/",
-				Source:          "broker.foobar.testbroker.dlx",
-				Destination:     "broker.foobar.testbroker.dlq",
+				Source:          "b.foobar.testbroker.dlx.broker-test-uid",
+				Destination:     "b.foobar.testbroker.dlq.broker-test-uid",
 				DestinationType: "queue",
 				RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
 					Name: rabbitmqcluster,
@@ -78,7 +81,7 @@ func TestNewBinding(t *testing.T) {
 		want: &rabbitv1beta1.Binding{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      "trigger.foobar.my-trigger",
+				Name:      "t.foobar.my-trigger.trigger-test-uid",
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						Kind:       "Trigger",
@@ -93,8 +96,8 @@ func TestNewBinding(t *testing.T) {
 			},
 			Spec: rabbitv1beta1.BindingSpec{
 				Vhost:           "/",
-				Source:          "broker.foobar.testbroker",
-				Destination:     "trigger.foobar.my-trigger",
+				Source:          "b.foobar.testbroker.broker-test-uid",
+				Destination:     "t.foobar.my-trigger.trigger-test-uid",
 				DestinationType: "queue",
 				RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
 					Name: rabbitmqcluster,
@@ -109,7 +112,7 @@ func TestNewBinding(t *testing.T) {
 		want: &rabbitv1beta1.Binding{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      "trigger.foobar.my-trigger",
+				Name:      "t.foobar.my-trigger.trigger-test-uid",
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						Kind:       "Trigger",
@@ -124,8 +127,8 @@ func TestNewBinding(t *testing.T) {
 			},
 			Spec: rabbitv1beta1.BindingSpec{
 				Vhost:           "/",
-				Source:          "broker.foobar.testbroker",
-				Destination:     "trigger.foobar.my-trigger",
+				Source:          "b.foobar.testbroker.broker-test-uid",
+				Destination:     "t.foobar.my-trigger.trigger-test-uid",
 				DestinationType: "queue",
 				RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
 					Name: rabbitmqcluster,
@@ -154,12 +157,13 @@ func TestNewTriggerDLQBinding(t *testing.T) {
 	want := &rabbitv1beta1.Binding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "trigger.foobar.my-trigger.dlq",
+			Name:      "t.foobar.my-trigger.dlq.trigger-test-uid",
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Kind:       "Trigger",
 					APIVersion: "eventing.knative.dev/v1",
 					Name:       triggerName,
+					UID:        triggerUID,
 				},
 			},
 			Labels: map[string]string{
@@ -169,8 +173,8 @@ func TestNewTriggerDLQBinding(t *testing.T) {
 		},
 		Spec: rabbitv1beta1.BindingSpec{
 			Vhost:           "/",
-			Source:          "trigger.foobar.my-trigger.dlx",
-			Destination:     "trigger.foobar.my-trigger.dlq",
+			Source:          "t.foobar.my-trigger.dlx.trigger-test-uid",
+			Destination:     "t.foobar.my-trigger.dlq.trigger-test-uid",
 			DestinationType: "queue",
 			RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
 				Name: rabbitmqcluster,
@@ -193,6 +197,7 @@ func createBroker() *eventingv1.Broker {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      brokerName,
+			UID:       brokerUID,
 		},
 		Spec: eventingv1.BrokerSpec{
 			Config: &v1.KReference{
@@ -207,6 +212,7 @@ func createTrigger() *eventingv1.Trigger {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      triggerName,
+			UID:       triggerUID,
 		},
 		Spec: eventingv1.TriggerSpec{},
 	}
@@ -217,6 +223,7 @@ func createTriggerWithFilter() *eventingv1.Trigger {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      triggerName,
+			UID:       triggerUID,
 		},
 		Spec: eventingv1.TriggerSpec{
 			Filter: &eventingv1.TriggerFilter{
@@ -233,6 +240,7 @@ func createTriggerWithFilterAndDelivery() *eventingv1.Trigger {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      triggerName,
+			UID:       triggerUID,
 		},
 		Spec: eventingv1.TriggerSpec{
 			Filter: &eventingv1.TriggerFilter{

--- a/pkg/reconciler/trigger/resources/queue_test.go
+++ b/pkg/reconciler/trigger/resources/queue_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	brokerresources "knative.dev/eventing-rabbitmq/pkg/reconciler/broker/resources"
+	naming "knative.dev/eventing-rabbitmq/pkg/rabbitmqnaming"
 	"knative.dev/eventing-rabbitmq/pkg/reconciler/trigger/resources"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
@@ -46,18 +46,19 @@ func TestNewQueue(t *testing.T) {
 		want: &rabbitv1beta1.Queue{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      "broker.foobar.testbroker.dlq",
+				Name:      "b.foobar.testbroker.dlq.broker-test-uid",
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						Kind:       "Broker",
 						APIVersion: "eventing.knative.dev/v1",
 						Name:       brokerName,
+						UID:        brokerUID,
 					},
 				},
 				Labels: map[string]string{"eventing.knative.dev/broker": "testbroker"},
 			},
 			Spec: rabbitv1beta1.QueueSpec{
-				Name:       "broker.foobar.testbroker.dlq",
+				Name:       "b.foobar.testbroker.dlq.broker-test-uid",
 				Durable:    true,
 				AutoDelete: false,
 				RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
@@ -72,12 +73,13 @@ func TestNewQueue(t *testing.T) {
 		want: &rabbitv1beta1.Queue{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      "trigger.foobar.my-trigger",
+				Name:      "t.foobar.my-trigger.trigger-test-uid",
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						Kind:       "Trigger",
 						APIVersion: "eventing.knative.dev/v1",
 						Name:       triggerName,
+						UID:        triggerUID,
 					},
 				},
 				Labels: map[string]string{
@@ -86,7 +88,7 @@ func TestNewQueue(t *testing.T) {
 				},
 			},
 			Spec: rabbitv1beta1.QueueSpec{
-				Name:       "trigger.foobar.my-trigger",
+				Name:       "t.foobar.my-trigger.trigger-test-uid",
 				Durable:    true,
 				AutoDelete: false,
 				RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
@@ -102,12 +104,13 @@ func TestNewQueue(t *testing.T) {
 		want: &rabbitv1beta1.Queue{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      "trigger.foobar.my-trigger",
+				Name:      "t.foobar.my-trigger.trigger-test-uid",
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						Kind:       "Trigger",
 						APIVersion: "eventing.knative.dev/v1",
 						Name:       triggerName,
+						UID:        triggerUID,
 					},
 				},
 				Labels: map[string]string{
@@ -116,7 +119,7 @@ func TestNewQueue(t *testing.T) {
 				},
 			},
 			Spec: rabbitv1beta1.QueueSpec{
-				Name:       "trigger.foobar.my-trigger",
+				Name:       "t.foobar.my-trigger.trigger-test-uid",
 				Durable:    true,
 				AutoDelete: false,
 				RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
@@ -132,12 +135,13 @@ func TestNewQueue(t *testing.T) {
 		want: &rabbitv1beta1.Queue{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      "trigger.foobar.my-trigger",
+				Name:      "t.foobar.my-trigger.trigger-test-uid",
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						Kind:       "Trigger",
 						APIVersion: "eventing.knative.dev/v1",
 						Name:       triggerName,
+						UID:        triggerUID,
 					},
 				},
 				Labels: map[string]string{
@@ -146,7 +150,7 @@ func TestNewQueue(t *testing.T) {
 				},
 			},
 			Spec: rabbitv1beta1.QueueSpec{
-				Name:       "trigger.foobar.my-trigger",
+				Name:       "t.foobar.my-trigger.trigger-test-uid",
 				Durable:    true,
 				AutoDelete: false,
 				RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
@@ -169,12 +173,13 @@ func TestNewTriggerDLQ(t *testing.T) {
 	want := &rabbitv1beta1.Queue{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "trigger.foobar.my-trigger.dlq",
+			Name:      "t.foobar.my-trigger.dlq.trigger-test-uid",
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Kind:       "Trigger",
 					APIVersion: "eventing.knative.dev/v1",
 					Name:       triggerName,
+					UID:        triggerUID,
 				},
 			},
 			Labels: map[string]string{
@@ -183,7 +188,7 @@ func TestNewTriggerDLQ(t *testing.T) {
 			},
 		},
 		Spec: rabbitv1beta1.QueueSpec{
-			Name:       "trigger.foobar.my-trigger.dlq",
+			Name:       "t.foobar.my-trigger.dlq.trigger-test-uid",
 			Durable:    true,
 			AutoDelete: false,
 			RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
@@ -200,7 +205,7 @@ func TestNewTriggerDLQ(t *testing.T) {
 
 func getTriggerQueueArguments() *runtime.RawExtension {
 	arguments := map[string]string{
-		"x-dead-letter-exchange": brokerresources.ExchangeName(createBroker(), true),
+		"x-dead-letter-exchange": naming.BrokerExchangeName(createBroker(), true),
 	}
 	argumentsJson, err := json.Marshal(arguments)
 	if err != nil {
@@ -213,7 +218,7 @@ func getTriggerQueueArguments() *runtime.RawExtension {
 
 func getTriggerQueueArgumentsWithDeadLetterSink() *runtime.RawExtension {
 	arguments := map[string]string{
-		"x-dead-letter-exchange": brokerresources.TriggerDLXExchangeName(createTriggerWithFilterAndDelivery()),
+		"x-dead-letter-exchange": naming.TriggerDLXExchangeName(createTriggerWithFilterAndDelivery()),
 	}
 	argumentsJson, err := json.Marshal(arguments)
 	if err != nil {

--- a/pkg/reconciler/triggerstandalone/resources/binding.go
+++ b/pkg/reconciler/triggerstandalone/resources/binding.go
@@ -24,7 +24,7 @@ import (
 	"net/url"
 	"reflect"
 
-	brokerresources "knative.dev/eventing-rabbitmq/pkg/reconciler/brokerstandalone/resources"
+	naming "knative.dev/eventing-rabbitmq/pkg/rabbitmqnaming"
 
 	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
@@ -76,7 +76,7 @@ func MakeBinding(transport http.RoundTripper, args *BindingArgs) error {
 		c.SetTransport(transport)
 	}
 
-	queueName := CreateTriggerQueueName(args.Trigger)
+	queueName := naming.CreateTriggerQueueName(args.Trigger)
 	arguments := map[string]interface{}{
 		"x-match":  interface{}("all"),
 		BindingKey: interface{}(args.Trigger.Name),
@@ -102,7 +102,7 @@ func MakeBinding(transport http.RoundTripper, args *BindingArgs) error {
 	if existing == nil || !reflect.DeepEqual(existing.Arguments, arguments) {
 		response, err := c.DeclareBinding("/", rabbithole.BindingInfo{
 			Vhost:           "/",
-			Source:          brokerresources.ExchangeName(args.Broker, false),
+			Source:          naming.BrokerExchangeName(args.Broker, false),
 			Destination:     queueName,
 			DestinationType: "queue",
 			RoutingKey:      args.RoutingKey,
@@ -182,9 +182,9 @@ func MakeDLQBinding(transport http.RoundTripper, args *BindingArgs) error {
 
 	var source string
 	if args.Trigger != nil {
-		source = brokerresources.TriggerDLXExchangeName(args.Trigger)
+		source = naming.TriggerDLXExchangeName(args.Trigger)
 	} else {
-		source = brokerresources.ExchangeName(args.Broker, true)
+		source = naming.BrokerExchangeName(args.Broker, true)
 	}
 
 	if existing == nil || !reflect.DeepEqual(existing.Arguments, arguments) {

--- a/pkg/reconciler/triggerstandalone/resources/dispatcher_test.go
+++ b/pkg/reconciler/triggerstandalone/resources/dispatcher_test.go
@@ -33,7 +33,9 @@ import (
 
 const (
 	brokerName       = "testbroker"
+	brokerUID        = "broker-test-uid"
 	triggerName      = "testtrigger"
+	triggerUID       = "trigger-test-uid"
 	ns               = "testnamespace"
 	image            = "dispatcherimage"
 	secretName       = "testbroker-broker-rabbit"
@@ -49,7 +51,7 @@ func TestMakeDispatcherDeployment(t *testing.T) {
 	ingressURL := apis.HTTP("broker.example.com")
 	sURL := apis.HTTP("function.example.com")
 	trigger := &eventingv1.Trigger{
-		ObjectMeta: metav1.ObjectMeta{Name: triggerName, Namespace: ns},
+		ObjectMeta: metav1.ObjectMeta{Name: triggerName, Namespace: ns, UID: triggerUID},
 		Spec:       eventingv1.TriggerSpec{Broker: brokerName},
 	}
 	args := &DispatcherArgs{
@@ -73,6 +75,7 @@ func TestMakeDispatcherDeployment(t *testing.T) {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Trigger",
 				Name:               triggerName,
+				UID:                triggerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -143,7 +146,7 @@ func TestMakeDispatcherDeploymentWithDelivery(t *testing.T) {
 	ingressURL := apis.HTTP("broker.example.com")
 	sURL := apis.HTTP("function.example.com")
 	trigger := &eventingv1.Trigger{
-		ObjectMeta: metav1.ObjectMeta{Name: triggerName, Namespace: ns},
+		ObjectMeta: metav1.ObjectMeta{Name: triggerName, Namespace: ns, UID: triggerUID},
 		Spec:       eventingv1.TriggerSpec{Broker: brokerName},
 	}
 	args := &DispatcherArgs{
@@ -171,6 +174,7 @@ func TestMakeDispatcherDeploymentWithDelivery(t *testing.T) {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Trigger",
 				Name:               triggerName,
+				UID:                triggerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
@@ -245,7 +249,7 @@ func TestMakeDLXDispatcherDeployment(t *testing.T) {
 	ingressURL := apis.HTTP("broker.example.com")
 	sURL := apis.HTTP("function.example.com")
 	trigger := &eventingv1.Trigger{
-		ObjectMeta: metav1.ObjectMeta{Name: triggerName, Namespace: ns},
+		ObjectMeta: metav1.ObjectMeta{Name: triggerName, Namespace: ns, UID: triggerUID},
 		Spec:       eventingv1.TriggerSpec{Broker: brokerName},
 	}
 	args := &DispatcherArgs{
@@ -270,6 +274,7 @@ func TestMakeDLXDispatcherDeployment(t *testing.T) {
 				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Trigger",
 				Name:               triggerName,
+				UID:                triggerUID,
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},

--- a/pkg/reconciler/triggerstandalone/resources/queue.go
+++ b/pkg/reconciler/triggerstandalone/resources/queue.go
@@ -17,8 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"fmt"
-
 	"github.com/streadway/amqp"
 	dialer "knative.dev/eventing-rabbitmq/pkg/amqp"
 	"knative.dev/eventing-rabbitmq/pkg/reconciler/io"
@@ -39,24 +37,6 @@ type QueueArgs struct {
 	Trigger *eventingv1.Trigger
 	// If non-empty, wire the queue into this DLX.
 	DLX string
-}
-
-func CreateBrokerDeadLetterQueueName(b *eventingv1.Broker) string {
-	// TODO(vaikas): https://github.com/knative-sandbox/eventing-rabbitmq/issues/61
-	// return fmt.Sprintf("%s/%s/DLQ", b.Namespace, b.Name)
-	return fmt.Sprintf("broker.%s.%s.dlq", b.Namespace, b.Name)
-}
-
-func CreateTriggerQueueName(t *eventingv1.Trigger) string {
-	// TODO(vaikas): https://github.com/knative-sandbox/eventing-rabbitmq/issues/61
-	// return fmt.Sprintf("%s/%s", t.Namespace, t.Name)
-	return fmt.Sprintf("trigger.%s.%s", t.Namespace, t.Name)
-}
-
-func CreateTriggerDeadLetterQueueName(t *eventingv1.Trigger) string {
-	// TODO(vaikas): https://github.com/knative-sandbox/eventing-rabbitmq/issues/61
-	// return fmt.Sprintf("%s/%s", t.Namespace, t.Name)
-	return fmt.Sprintf("trigger.%s.%s.dlq", t.Namespace, t.Name)
 }
 
 // DeclareQueue declares the Trigger's Queue.

--- a/pkg/reconciler/triggerstandalone/trigger.go
+++ b/pkg/reconciler/triggerstandalone/trigger.go
@@ -167,7 +167,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *eventingv1.Trigger) p
 			DLX:         true,
 			RabbitMQURL: exchangeURL,
 		}
-		fmt.Printf("CREATING TRIGGER EXCHANGE: %+v\n", args)
 		_, err = brokerresources.DeclareExchange(r.dialerFunc, args)
 		if err != nil {
 			t.Status.MarkDependencyFailed("ExchangeFailure", fmt.Sprintf("Failed to reconcile trigger DLX exchange %q: %s", brokerresources.TriggerDLXExchangeName(t), err))

--- a/pkg/reconciler/triggerstandalone/trigger.go
+++ b/pkg/reconciler/triggerstandalone/trigger.go
@@ -167,6 +167,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *eventingv1.Trigger) p
 			DLX:         true,
 			RabbitMQURL: exchangeURL,
 		}
+		fmt.Printf("CREATING TRIGGER EXCHANGE: %+v\n", args)
 		_, err = brokerresources.DeclareExchange(r.dialerFunc, args)
 		if err != nil {
 			t.Status.MarkDependencyFailed("ExchangeFailure", fmt.Sprintf("Failed to reconcile trigger DLX exchange %q: %s", brokerresources.TriggerDLXExchangeName(t), err))

--- a/pkg/reconciler/triggerstandalone/trigger_test.go
+++ b/pkg/reconciler/triggerstandalone/trigger_test.go
@@ -80,7 +80,7 @@ const (
 	triggerUID  = "test-trigger-uid"
 
 	rabbitURL = "amqp://localhost:5672/%2f"
-	queueName = "trigger.test-namespace.test-trigger"
+	queueName = "t.test-namespace.test-trigger.test-trigger-uid"
 
 	dispatcherImage = "dispatcherimage"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

Fixes: #343 

Create sane names for RabbitMQ resources. Basically uses the UID of the controlling resource using standard kmeta.ChildName.

Builds on #341

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
 :broom: Use better names for all RabbitMQ resources. Both k8s resources as well as RabbitMQ resources for standalone Broker.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
