### PR TITLE
bump eventing test versions

### DIFF
--- a/.github/workflows/kind-conformance-standalone.yaml
+++ b/.github/workflows/kind-conformance-standalone.yaml
@@ -25,7 +25,7 @@ jobs:
         - v1.22.1
 
         eventing-version:
-        - v0.23.0
+        - v0.25.0
 
         rabbitmq-operator-version:
         - v1.8.2

--- a/.github/workflows/kind-conformance.yaml
+++ b/.github/workflows/kind-conformance.yaml
@@ -25,7 +25,7 @@ jobs:
         - v1.22.1
 
         eventing-version:
-        - v0.23.0
+        - v0.25.0
 
         rabbitmq-operator-version:
         - v1.8.2

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,9 +20,9 @@ jobs:
         - v1.22.1
 
         eventing-version:
-        - v0.21.0
-        - v0.22.0
         - v0.23.0
+        - v0.24.0
+        - v0.25.0
 
         rabbitmq-operator-version:
         - v1.8.2


### PR DESCRIPTION
Bump the versions we test against to the latest 3. It would be nice if we had some automation around this, but a problem for another day 😄 