### PR TITLE
Switch broker DLQ test to use a k8s Service

### DIFF
--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -82,7 +82,7 @@ const (
 
 	deadLetterSinkKind       = "Service"
 	deadLetterSinkName       = "badsink"
-	deadLetterSinkAPIVersion = "serving.knative.dev/v1"
+	deadLetterSinkAPIVersion = "v1"
 
 	dispatcherImage = "dispatcherimage"
 )
@@ -968,13 +968,13 @@ func TestReconcile(t *testing.T) {
 					WithBrokerDelivery(deliveryUnresolvableDeadLetterSink),
 					WithIngressAvailable(),
 					WithDLXReady(),
-					WithDeadLetterSinkFailed("Unable to get the DeadLetterSink's URI", `services.serving.knative.dev "badsink" not found`),
+					WithDeadLetterSinkFailed("Unable to get the DeadLetterSink's URI", `services "badsink" not found`),
 					WithSecretReady(),
 					WithBrokerAddressURI(brokerAddress),
 					WithExchangeReady()),
 			}},
 			WantEvents: []string{
-				Eventf(corev1.EventTypeWarning, "InternalError", `services.serving.knative.dev "badsink" not found`),
+				Eventf(corev1.EventTypeWarning, "InternalError", `services "badsink" not found`),
 			},
 			WantErr: true,
 		},


### PR DESCRIPTION
With upcoming changes to eventing DLQs will be defaulted to the
namespace of their parent object if the namespace isn't specified in the
ref. For some reason this causes a panic from the fake dynamic client
that doesn't occur if the namespace isn't specified.

It happens because ksvcs have been registered with the fake dynamic
client as a type, but I'm not really sure why they only panic when a
namespace is present.

xref https://github.com/knative/eventing/pull/5748 for the namespace
defaulting change
xref https://github.com/knative/eventing/issues/5185 for more discussion of
the changed behavior of client-go fake dynamic clients.

/assign @dprotaso 