### PR TITLE
Switch broker DLQ test to use a k8s Service (again)

### DIFF
--- a/pkg/reconciler/brokerstandalone/broker_test.go
+++ b/pkg/reconciler/brokerstandalone/broker_test.go
@@ -82,7 +82,7 @@ const (
 
 	deadLetterSinkKind       = "Service"
 	deadLetterSinkName       = "badsink"
-	deadLetterSinkAPIVersion = "serving.knative.dev/v1"
+	deadLetterSinkAPIVersion = "v1"
 
 	dispatcherImage = "dispatcherimage"
 
@@ -825,7 +825,7 @@ func TestReconcile(t *testing.T) {
 					WithBrokerDelivery(deliveryUnresolvableDeadLetterSink),
 					WithIngressAvailable(),
 					WithDLXReady(),
-					WithDeadLetterSinkFailed("Unable to get the DeadLetterSink's URI", `services.serving.knative.dev "badsink" not found`),
+					WithDeadLetterSinkFailed("Unable to get the DeadLetterSink's URI", `services "badsink" not found`),
 					WithSecretReady(),
 					WithBrokerAddressURI(brokerAddress),
 					WithExchangeReady()),
@@ -840,7 +840,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", `Updated "test-broker" finalizers`),
-				Eventf(corev1.EventTypeWarning, "InternalError", `services.serving.knative.dev "badsink" not found`),
+				Eventf(corev1.EventTypeWarning, "InternalError", `services "badsink" not found`),
 			},
 			WantErr: true,
 		},


### PR DESCRIPTION
In #433 I forgot to also copy this change to the standalone broker test

/assign @dprotaso 