### PR TITLE
Spec based msg formating implementation

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -370,7 +370,6 @@ func convertToCloudEvent(event *cloudevents.Event, msg wabbit.Delivery, a *Adapt
 	event.SetType(sourcesv1alpha1.RabbitmqEventType)
 	event.SetSource(sourcesv1alpha1.RabbitmqEventSource(a.config.Namespace, a.config.Name, a.config.Topic))
 	event.SetSubject(event.ID())
-	event.SetExtension("key", event.ID())
 	event.SetTime(msg.Timestamp())
 	err := event.SetData(msg.ContentType(), msg.Body())
 	if err != nil {

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -25,11 +25,14 @@ import (
 	"github.com/NeowayLabs/wabbit"
 	"github.com/NeowayLabs/wabbit/amqp"
 	"github.com/NeowayLabs/wabbit/amqptest"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/protocol/http"
+
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/util/uuid"
+
 	sourcesv1alpha1 "knative.dev/eventing-rabbitmq/pkg/apis/sources/v1alpha1"
 	"knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/eventing/pkg/kncloudevents"
@@ -37,9 +40,7 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-const (
-	resourceGroup = "rabbitmqsources.sources.knative.dev"
-)
+const resourceGroup = "rabbitmqsources.sources.knative.dev"
 
 type ExchangeConfig struct {
 	Name        string `envconfig:"RABBITMQ_EXCHANGE_CONFIG_NAME" required:"false"`
@@ -309,32 +310,36 @@ func (a *Adapter) postMessage(msg wabbit.Delivery) error {
 		return err
 	}
 
-	// TODO: See if the message is already a Cloud Event and if so, do not wrap, just use as is.
-	event := cloudevents.NewEvent()
-	if msg.MessageId() != "" {
-		event.SetID(msg.MessageId())
+	msgBinding := NewMessageFromDelivery(msg)
+
+	defer func() {
+		err := msgBinding.Finish(nil)
+		if err != nil {
+			a.logger.Error("Something went wrong while trying to finalizing the message", zap.Error(err))
+		}
+	}()
+
+	// if the msg is a cloudevent we send it as it is to http
+	if msgBinding.ReadEncoding() != binding.EncodingUnknown {
+		err = http.WriteRequest(a.context, msgBinding, req)
 	} else {
-		event.SetID(string(uuid.NewUUID()))
-	}
-	event.SetTime(msg.Timestamp())
-	event.SetType(sourcesv1alpha1.RabbitmqEventType)
-	event.SetSource(sourcesv1alpha1.RabbitmqEventSource(a.config.Namespace, a.config.Name, a.config.Topic))
-	event.SetSubject(msg.MessageId())
-	event.SetExtension("key", msg.MessageId())
+		// if the rabbitmq msg is not a cloudevent we transform it into one
+		event := cloudevents.NewEvent()
+		err = convertToCloudEvent(&event, msg, a)
+		if err != nil {
+			a.logger.Error("Error converting RabbitMQ msg to CloudEvent", zap.Error(err))
+			return err
+		}
 
-	// TODO: Check the content type and use it instead.
-	err = event.SetData(*cloudevents.StringOfApplicationJSON(), msg.Body())
-	if err != nil {
-		return err
+		err = http.WriteRequest(a.context, binding.ToMessage(&event), req)
 	}
 
-	err = http.WriteRequest(a.context, binding.ToMessage(&event), req)
 	if err != nil {
+		a.logger.Error(fmt.Sprintf("Error writting event to http, encoding: %s", msgBinding.ReadEncoding()), zap.Error(err))
 		return err
 	}
 
 	res, err := a.httpMessageSender.Send(req)
-
 	if err != nil {
 		a.logger.Debug("Error while sending the message", zap.Error(err))
 		return err
@@ -352,6 +357,26 @@ func (a *Adapter) postMessage(msg wabbit.Delivery) error {
 	}
 
 	_ = a.reporter.ReportEventCount(reportArgs, res.StatusCode)
+	return nil
+}
+
+func convertToCloudEvent(event *cloudevents.Event, msg wabbit.Delivery, a *Adapter) error {
+	if msg.MessageId() != "" {
+		event.SetID(msg.MessageId())
+	} else {
+		event.SetID(string(uuid.NewUUID()))
+	}
+
+	event.SetType(sourcesv1alpha1.RabbitmqEventType)
+	event.SetSource(sourcesv1alpha1.RabbitmqEventSource(a.config.Namespace, a.config.Name, a.config.Topic))
+	event.SetSubject(event.ID())
+	event.SetExtension("key", event.ID())
+	event.SetTime(msg.Timestamp())
+	err := event.SetData(msg.ContentType(), msg.Body())
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -341,12 +341,12 @@ func (a *Adapter) postMessage(msg wabbit.Delivery) error {
 
 	res, err := a.httpMessageSender.Send(req)
 	if err != nil {
-		a.logger.Debug("Error while sending the message", zap.Error(err))
+		a.logger.Error("Error while sending the message", zap.Error(err))
 		return err
 	}
 
 	if res.StatusCode/100 != 2 {
-		a.logger.Debug("Unexpected status code", zap.Int("status code", res.StatusCode))
+		a.logger.Error("Unexpected status code", zap.Int("status code", res.StatusCode))
 		return fmt.Errorf("%d %s", res.StatusCode, nethttp.StatusText(res.StatusCode))
 	}
 

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -319,11 +319,11 @@ func (a *Adapter) postMessage(msg wabbit.Delivery) error {
 		}
 	}()
 
-	// if the msg is a cloudevent we send it as it is to http
+	// if the msg is a cloudevent send it as it is to http
 	if msgBinding.ReadEncoding() != binding.EncodingUnknown {
 		err = http.WriteRequest(a.context, msgBinding, req)
 	} else {
-		// if the rabbitmq msg is not a cloudevent we transform it into one
+		// if the rabbitmq msg is not a cloudevent transform it into one
 		event := cloudevents.NewEvent()
 		err = convertToCloudEvent(&event, msg, a)
 		if err != nil {

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,7 +31,6 @@ import (
 	"github.com/NeowayLabs/wabbit/amqp"
 	"github.com/NeowayLabs/wabbit/amqptest"
 	"github.com/NeowayLabs/wabbit/amqptest/server"
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 	origamqp "github.com/rabbitmq/amqp091-go"
 	"go.uber.org/zap"
 
@@ -42,12 +42,13 @@ import (
 
 func TestPostMessage_ServeHTTP(t *testing.T) {
 	testCases := map[string]struct {
-		sink              func(http.ResponseWriter, *http.Request)
-		reqBody           string
-		attributes        map[string]string
-		expectedEventType string
-		withMsgId         bool
-		error             bool
+		sink                       func(http.ResponseWriter, *http.Request)
+		reqBody, expectedEventType string
+		reqHeaders                 http.Header
+		data                       map[string]interface{}
+		headers                    wabbit.Option
+		attributes                 map[string]string
+		withMsgId, isCe, error     bool
 	}{
 		"accepted": {
 			sink:    sinkAccepted,
@@ -58,6 +59,44 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 			sink:      sinkAccepted,
 			reqBody:   `{"key":"value"}`,
 			withMsgId: true,
+			data:      map[string]interface{}{"key": "value"},
+		},
+		"accepted with binary cloudevent": {
+			sink:      sinkAccepted,
+			reqBody:   `{"test":"test"}`,
+			withMsgId: true,
+			reqHeaders: http.Header{
+				"Ce-Specversion": []string{"1.0"},
+				"Ce-Source":      []string{"example/source.uri"},
+				"Ce-Testheader":  []string{"testHeader"},
+			},
+			data: map[string]interface{}{
+				"test": "test",
+			},
+			headers: wabbit.Option{
+				"ce-specversion": "1.0",
+				"ce-source":      "example/source.uri",
+				"ce-testheader":  "testHeader",
+				"ignore":         "ignore",
+			},
+			isCe: true,
+		},
+		"accepted with structured cloudevent": {
+			sink: sinkAccepted,
+			reqBody: `{"specversion":"1.0","id":1234,` +
+				`"type":"dev.knative.rabbitmq.event","source":"example/source.uri",` +
+				`"content-type":"text/plain","data":"test"}`,
+			withMsgId: true,
+			headers:   wabbit.Option{"content-type": "application/cloudevents+json"},
+			data: map[string]interface{}{
+				"specversion":  "1.0",
+				"id":           1234,
+				"type":         "dev.knative.rabbitmq.event",
+				"source":       "example/source.uri",
+				"content-type": "text/plain",
+				"data":         "test",
+			},
+			isCe: true,
 		},
 		"rejected": {
 			sink:    sinkRejected,
@@ -128,8 +167,32 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 				t.Errorf("expected error, but got %v", err)
 			}
 
-			if tc.reqBody != string(h.body) {
-				t.Errorf("Expected request body '%q', but got '%q' %s", tc.reqBody, h.body, err)
+			var wantBody, gotBody map[string]interface{}
+			err = json.Unmarshal([]byte(tc.reqBody), &wantBody)
+			if err != nil {
+				t.Errorf("Error unmarshaling wanted request body %s %s", tc.reqBody, err)
+			}
+
+			err = json.Unmarshal([]byte(tc.reqBody), &gotBody)
+			if err != nil {
+				t.Errorf("Error unmarshaling got request body %s %s", h.body, err)
+			}
+
+			if len(wantBody) > 0 && len(wantBody) != len(gotBody) && !reflect.DeepEqual(wantBody, gotBody) {
+				t.Errorf("Expected request body '%s', but got '%s' %s", tc.reqBody, h.body, err)
+			}
+
+			if tc.isCe {
+				ceHeaders := http.Header{}
+				for key, value := range h.header {
+					if strings.HasPrefix(key, "Ce-") {
+						ceHeaders[key] = value
+					}
+				}
+
+				if len(ceHeaders) > 0 && len(ceHeaders) != len(tc.reqHeaders) && !reflect.DeepEqual(ceHeaders, tc.reqHeaders) {
+					t.Errorf("Expected request headers '%s', but got '%s' %s", tc.reqHeaders, ceHeaders, err)
+				}
 			}
 		})
 	}
@@ -640,242 +703,5 @@ func TestAdapter_NewAdapter(t *testing.T) {
 
 	if a == cmpA {
 		t.Errorf("Error in NewnvConfig return Type")
-	}
-}
-
-func TestAdapter_MsgIsBinary(t *testing.T) {
-	for _, tt := range []struct {
-		name       string
-		msgHeaders wabbit.Option
-		want       bool
-	}{{
-		name:       "msg with empty headers",
-		msgHeaders: wabbit.Option{},
-		want:       false,
-	}, {
-		name:       "msg is not binary",
-		msgHeaders: wabbit.Option{"content-type": "test"},
-		want:       false,
-	}, {
-		name:       "msg is binary",
-		msgHeaders: wabbit.Option{"ce-specversion": "1.0"},
-		want:       true,
-	}, {
-		name:       "msg is binary, titlecase",
-		msgHeaders: wabbit.Option{"Ce-Specversion": "1.0"},
-		want:       true,
-	}} {
-		t.Run(tt.name, func(t *testing.T) {
-			tt := tt
-			t.Parallel()
-			got := isBinary(tt.msgHeaders)
-			if got != tt.want {
-				t.Errorf("Unexpected msg encoding for %s want:\n%v\ngot:\n%v", tt.msgHeaders, tt.want, got)
-			}
-		})
-	}
-}
-
-func TestAdapter_MsgIsStructured(t *testing.T) {
-	for _, tt := range []struct {
-		name    string
-		msgBody map[string]interface{}
-		want    bool
-	}{{
-		name:    "msg with empty body",
-		msgBody: map[string]interface{}{},
-		want:    false,
-	}, {
-		name:    "msg is not structured",
-		msgBody: map[string]interface{}{"data": "test"},
-		want:    false,
-	}, {
-		name:    "msg is structured",
-		msgBody: map[string]interface{}{"specversion": "1.0"},
-		want:    true,
-	}, {
-		name:    "msg is structured, titlecase",
-		msgBody: map[string]interface{}{"Specversion": "1.0"},
-		want:    true,
-	}} {
-		t.Run(tt.name, func(t *testing.T) {
-			tt := tt
-			t.Parallel()
-			got := isStructured(tt.msgBody)
-			if got != tt.want {
-				t.Errorf("Unexpected msg encoding for %s want:\n%v\ngot:\n%v", tt.msgBody, tt.want, got)
-			}
-		})
-	}
-}
-
-func TestAdapter_MsgSetEventAttributes(t *testing.T) {
-	// Specversion is mandatory in ce v1.0
-	for _, tt := range []struct {
-		name    string
-		key     string
-		ceKey   string
-		val     interface{}
-		want    string
-		wantErr bool
-	}{{
-		name:  "empty string val",
-		key:   "test",
-		ceKey: "ce-test",
-		val:   "",
-		want:  `{"specversion": "1.0", "test": ""}`,
-	}, {
-		name:    "nil val err",
-		key:     "test",
-		ceKey:   "ce-test",
-		val:     nil,
-		want:    `{"specversion": "1.0"}`,
-		wantErr: true,
-	}, {
-		name:    "wrong cloudevents key with '-'",
-		key:     "wrong-key",
-		ceKey:   "ce-wrong-key",
-		val:     "test",
-		want:    `{"specversion": "1.0"}`,
-		wantErr: true,
-	}, {
-		name:  "set extension attribute",
-		key:   "test",
-		ceKey: "ce-test",
-		val:   "test",
-		want:  `{"specversion": "1.0", "test": "test"}`,
-	}, {
-		name:  "set cloudEvents attribute",
-		key:   "source",
-		ceKey: "ce-source",
-		val:   "example/source.uri",
-		want:  `{"specversion": "1.0", "source": "example/source.uri"}`,
-	}, {
-		name:  "floating numbers aproximation conversion to string",
-		key:   "floatVal",
-		ceKey: "ce-floatVal",
-		val:   0.34,
-		want:  `{"specversion": "1.0", "floatVal": 0}`,
-	}} {
-		t.Run(tt.name, func(t *testing.T) {
-			tt := tt
-			t.Parallel()
-
-			wantEvent := cloudevents.NewEvent()
-			err := json.Unmarshal([]byte(tt.want), &wantEvent)
-			if err != nil {
-				t.Error(err)
-			}
-
-			gotEvent := cloudevents.NewEvent()
-			err = setEventAttributes(&gotEvent, tt.key, tt.ceKey, tt.val)
-			if err != nil && !tt.wantErr {
-				t.Errorf("Unexpected error for:\nkey: %s, ceKey:%s, val: %s\nerr: %s", tt.key, tt.ceKey, tt.val, err)
-			}
-
-			if !tt.wantErr && gotEvent.String() != wantEvent.String() {
-				t.Errorf("Unexpected event translation want:\n%v\ngot:\n%v", wantEvent, gotEvent)
-			}
-		})
-	}
-}
-
-func TestAdapter_SetBinaryMessageProperties(t *testing.T) {
-	for _, tt := range []struct {
-		name       string
-		msgHeaders wabbit.Option
-		want       string
-		wantErr    bool
-	}{{
-		name:       "msg with empty headers",
-		msgHeaders: wabbit.Option{},
-		want:       `{"specversion": "1.0"}`,
-	}, {
-		name:       "malformed cloudevents key",
-		msgHeaders: wabbit.Option{"ce-wrong-key": "test"},
-		want:       `{"specversion": "1.0"}`,
-		wantErr:    true,
-	}, {
-		name:       "msg with one extension with floating value translated to lower key",
-		msgHeaders: wabbit.Option{"Ce-Test": 0.3},
-		want:       `{"specversion": "1.0", "test": "0"}`,
-	}, {
-		name:       "msg with one cloudevent attribute",
-		msgHeaders: wabbit.Option{"ce-source": "example/source.uri"},
-		want:       `{"specversion": "1.0", "source": "example/source.uri"}`,
-	}, {
-		name:       "msg ignore not ce- prefixed headers",
-		msgHeaders: wabbit.Option{"test": "test"},
-		want:       `{"specversion": "1.0"}`,
-	}, {
-		name:       "multi case event translation",
-		msgHeaders: wabbit.Option{"test": "test", "ce-source": "example/source.uri", "ce-test": 0.6},
-		want:       `{"specversion": "1.0", "source": "example/source.uri", "test": "0"}`,
-	}} {
-		t.Run(tt.name, func(t *testing.T) {
-			tt := tt
-			t.Parallel()
-
-			wantEvent := cloudevents.NewEvent()
-			err := json.Unmarshal([]byte(tt.want), &wantEvent)
-			if err != nil {
-				t.Error(err)
-			}
-
-			gotEvent := cloudevents.NewEvent()
-			err = setBinaryMessageProperties(&gotEvent, tt.msgHeaders)
-			if err != nil && !tt.wantErr {
-				t.Errorf("Unexpected error for:\nheaders: %s", tt.msgHeaders)
-			}
-
-			if gotEvent.String() != wantEvent.String() {
-				t.Errorf("Unexpected binary event properties set:\n%v\ngot:\n%v", wantEvent, gotEvent)
-			}
-		})
-	}
-}
-
-func TestAdapter_SetStructuredMessageProperties(t *testing.T) {
-	for _, tt := range []struct {
-		name    string
-		msgBody map[string]interface{}
-		want    string
-	}{{
-		name:    "msg with empty headers",
-		msgBody: map[string]interface{}{},
-		want:    `{"specversion": "1.0"}`,
-	}, {
-		name:    "msg with one extension with floating value",
-		msgBody: map[string]interface{}{"test": 0.3},
-		want:    `{"specversion": "1.0", "test": "0"}`,
-	}, {
-		name:    "msg transalate to lower key valid ce keys",
-		msgBody: map[string]interface{}{"Source": "example/source.uri"},
-		want:    `{"specversion": "1.0", "source": "example/source.uri"}`,
-	}, {
-		name:    "multi case event translation",
-		msgBody: map[string]interface{}{"source": "example/source.uri", "test": 0.6},
-		want:    `{"specversion": "1.0", "source": "example/source.uri", "test": "0"}`,
-	}} {
-		t.Run(tt.name, func(t *testing.T) {
-			tt := tt
-			t.Parallel()
-
-			wantEvent := cloudevents.NewEvent()
-			err := json.Unmarshal([]byte(tt.want), &wantEvent)
-			if err != nil {
-				t.Error(err)
-			}
-
-			gotEvent := cloudevents.NewEvent()
-			err = setStructuredMessageProperties(&gotEvent, tt.msgBody)
-			if err != nil {
-				t.Errorf("Unexpected error for:\nheaders: %s", tt.msgBody)
-			}
-
-			if gotEvent.String() != wantEvent.String() {
-				t.Errorf("Unexpected binary event properties set:\n%v\ngot:\n%v", wantEvent, gotEvent)
-			}
-		})
 	}
 }

--- a/pkg/adapter/message.go
+++ b/pkg/adapter/message.go
@@ -70,7 +70,6 @@ func NewMessageFromDelivery(msg wabbit.Delivery) *Message {
 
 // NewMessage returns a binding.Message that holds the provided rabbitmq message components.
 // The returned binding.Message *can* be read several times safely
-// This function *doesn't* guarantee that the returned binding.Message is always a wabbit.Delivery instance
 func NewMessage(value []byte, contentType string, headers map[string][]byte) *Message {
 	if ft := format.Lookup(contentType); ft != nil {
 		return &Message{

--- a/pkg/adapter/message.go
+++ b/pkg/adapter/message.go
@@ -57,7 +57,7 @@ func NewMessageFromDelivery(msg wabbit.Delivery) *Message {
 	var contentType string
 	headers := make(map[string][]byte, len(msg.Headers()))
 	for key, val := range msg.Headers() {
-		k := strings.ToLower(string(key))
+		k := strings.ToLower(key)
 		if k == contentTypeHeader {
 			contentType = val.(string)
 		}
@@ -123,6 +123,7 @@ func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) 
 		} else if k == contentTypeHeader {
 			err = encoder.SetAttribute(m.version.AttributeFromKind(spec.DataContentType), string(v))
 		}
+
 		if err != nil {
 			return
 		}
@@ -139,6 +140,7 @@ func (m *Message) ReadStructured(ctx context.Context, encoder binding.Structured
 	if m.format != nil {
 		return encoder.SetStructuredEvent(ctx, m.format, bytes.NewReader(m.Value))
 	}
+
 	return binding.ErrNotStructured
 }
 
@@ -147,6 +149,7 @@ func (m *Message) GetAttribute(k spec.Kind) (spec.Attribute, interface{}) {
 	if attr != nil {
 		return attr, string(m.Headers[attr.PrefixedName()])
 	}
+
 	return nil, nil
 }
 

--- a/pkg/adapter/message.go
+++ b/pkg/adapter/message.go
@@ -51,7 +51,7 @@ type Message struct {
 var _ binding.Message = (*Message)(nil)
 var _ binding.MessageMetadataReader = (*Message)(nil)
 
-// NewMessageFromConsumerMessage returns a binding.Message that holds the provided ConsumerMessage.
+// NewMessageFromDelivery returns a binding.Message that holds the provided RabbitMQ Message.
 // The returned binding.Message *can* be read several times safely
 // This function *doesn't* guarantee that the returned binding.Message is always a rabbitmq.Message instance
 func NewMessageFromDelivery(msg wabbit.Delivery) *Message {

--- a/pkg/adapter/message.go
+++ b/pkg/adapter/message.go
@@ -53,7 +53,6 @@ var _ binding.MessageMetadataReader = (*Message)(nil)
 
 // NewMessageFromDelivery returns a binding.Message that holds the provided RabbitMQ Message.
 // The returned binding.Message *can* be read several times safely
-// This function *doesn't* guarantee that the returned binding.Message is always a rabbitmq.Message instance
 func NewMessageFromDelivery(msg wabbit.Delivery) *Message {
 	var contentType string
 	headers := make(map[string][]byte, len(msg.Headers()))

--- a/pkg/adapter/message.go
+++ b/pkg/adapter/message.go
@@ -19,6 +19,7 @@ package rabbitmq
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/NeowayLabs/wabbit"
@@ -62,7 +63,7 @@ func NewMessageFromDelivery(msg wabbit.Delivery) *Message {
 			contentType = val.(string)
 		}
 
-		headers[k] = []byte(val.(string))
+		headers[k] = []byte(fmt.Sprint(val))
 	}
 
 	return NewMessage(msg.Body(), contentType, headers)

--- a/pkg/adapter/message.go
+++ b/pkg/adapter/message.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/NeowayLabs/wabbit"
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/format"
+	"github.com/cloudevents/sdk-go/v2/binding/spec"
+)
+
+const (
+	prefix            = "ce-"
+	contentTypeHeader = "content-type"
+)
+
+var (
+	specs = spec.WithPrefix(prefix)
+)
+
+// Message holds a rabbitmq message.
+// this message *can* be read several times safely
+type Message struct {
+	Value       []byte
+	Headers     map[string][]byte
+	ContentType string
+	format      format.Format
+	version     spec.Version
+}
+
+// Check if http.Message implements binding.Message
+var _ binding.Message = (*Message)(nil)
+var _ binding.MessageMetadataReader = (*Message)(nil)
+
+// NewMessageFromConsumerMessage returns a binding.Message that holds the provided ConsumerMessage.
+// The returned binding.Message *can* be read several times safely
+// This function *doesn't* guarantee that the returned binding.Message is always a rabbitmq.Message instance
+func NewMessageFromDelivery(msg wabbit.Delivery) *Message {
+	var contentType string
+	headers := make(map[string][]byte, len(msg.Headers()))
+	for key, val := range msg.Headers() {
+		k := strings.ToLower(string(key))
+		if k == contentTypeHeader {
+			contentType = val.(string)
+		}
+
+		headers[k] = []byte(val.(string))
+	}
+
+	return NewMessage(msg.Body(), contentType, headers)
+}
+
+// NewMessage returns a binding.Message that holds the provided rabbitmq message components.
+// The returned binding.Message *can* be read several times safely
+// This function *doesn't* guarantee that the returned binding.Message is always a wabbit.Delivery instance
+func NewMessage(value []byte, contentType string, headers map[string][]byte) *Message {
+	if ft := format.Lookup(contentType); ft != nil {
+		return &Message{
+			Value:       value,
+			ContentType: contentType,
+			Headers:     headers,
+			format:      ft,
+		}
+	} else if v := specs.Version(string(headers[specs.PrefixedSpecVersionName()])); v != nil {
+		return &Message{
+			Value:       value,
+			ContentType: contentType,
+			Headers:     headers,
+			version:     v,
+		}
+	}
+
+	return &Message{
+		Value:       value,
+		ContentType: contentType,
+		Headers:     headers,
+	}
+}
+
+func (m *Message) ReadEncoding() binding.Encoding {
+	if m.version != nil {
+		return binding.EncodingBinary
+	}
+
+	if m.format != nil {
+		return binding.EncodingStructured
+	}
+
+	return binding.EncodingUnknown
+}
+
+func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) (err error) {
+	if m.version == nil {
+		return binding.ErrNotBinary
+	}
+
+	for k, v := range m.Headers {
+		if strings.HasPrefix(k, prefix) {
+			attr := m.version.Attribute(k)
+			if attr != nil {
+				err = encoder.SetAttribute(attr, string(v))
+			} else {
+				err = encoder.SetExtension(strings.TrimPrefix(k, prefix), string(v))
+			}
+		} else if k == contentTypeHeader {
+			err = encoder.SetAttribute(m.version.AttributeFromKind(spec.DataContentType), string(v))
+		}
+		if err != nil {
+			return
+		}
+	}
+
+	if m.Value != nil {
+		err = encoder.SetData(bytes.NewBuffer(m.Value))
+	}
+
+	return
+}
+
+func (m *Message) ReadStructured(ctx context.Context, encoder binding.StructuredWriter) error {
+	if m.format != nil {
+		return encoder.SetStructuredEvent(ctx, m.format, bytes.NewReader(m.Value))
+	}
+	return binding.ErrNotStructured
+}
+
+func (m *Message) GetAttribute(k spec.Kind) (spec.Attribute, interface{}) {
+	attr := m.version.AttributeFromKind(k)
+	if attr != nil {
+		return attr, string(m.Headers[attr.PrefixedName()])
+	}
+	return nil, nil
+}
+
+func (m *Message) GetExtension(name string) interface{} {
+	return string(m.Headers[prefix+name])
+}
+
+func (m *Message) Finish(error) error {
+	return nil
+}

--- a/pkg/adapter/message_test.go
+++ b/pkg/adapter/message_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbitmq
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/spec"
+	bindingtest "github.com/cloudevents/sdk-go/v2/binding/test"
+)
+
+func TestAdapter_MsgReadBinary(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		headers map[string][]byte
+		kind    spec.Kind
+		version spec.Version
+		want    interface{}
+	}{{
+		name:    "err not binary",
+		headers: map[string][]byte{},
+		kind:    spec.Kind(0),
+		version: nil,
+		want:    binding.ErrNotBinary,
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+
+			m := Message{
+				Headers: tt.headers,
+				version: tt.version,
+			}
+
+			mb := bindingtest.MockBinaryMessage{}
+			err := m.ReadBinary(context.TODO(), &mb)
+			if err != tt.want {
+				t.Errorf("Unexpected error %s ", err)
+			}
+		})
+	}
+}
+
+func TestAdapter_MsgGetAttribute(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		headers map[string][]byte
+		kind    spec.Kind
+		want    interface{}
+	}{{
+		name:    "get empty attribute",
+		headers: map[string][]byte{},
+		kind:    spec.Kind(0),
+		want:    "",
+	}, {
+		name:    "get msg id from kind",
+		headers: map[string][]byte{"id": []byte("1234")},
+		kind:    spec.Kind(0),
+		want:    "1234",
+	}, {
+		name:    "get non existent attribute",
+		headers: map[string][]byte{"does not exist": []byte("test")},
+		kind:    spec.Kind(16),
+		want:    nil,
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+
+			m := Message{
+				Headers: tt.headers,
+				version: spec.V1,
+			}
+
+			attr, got := m.GetAttribute(tt.kind)
+			if got != tt.want {
+				t.Errorf("Unexpected attribute value %s want:\n%v\ngot:\n%v", attr, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestAdapter_MsgGetExtension(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		headers map[string][]byte
+		extName string
+		want    string
+	}{{
+		name:    "get empty extension",
+		headers: map[string][]byte{},
+		extName: "invalid",
+		want:    "",
+	}, {
+		name:    "get msg extension",
+		headers: map[string][]byte{"ce-extension": []byte("test")},
+		extName: "extension",
+		want:    "test",
+	}, {
+		name:    "get msg extension different value",
+		headers: map[string][]byte{"ce-different": []byte("testing this again 1")},
+		extName: "different",
+		want:    "testing this again 1",
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+
+			m := Message{
+				Headers: tt.headers,
+			}
+
+			got := m.GetExtension(tt.extName)
+			if got != tt.want {
+				t.Errorf("Unexpected extension value %s want:\n%v\ngot:\n%v", tt.extName, tt.want, got)
+			}
+		})
+	}
+}

--- a/test/e2e/cmd/rabbitproducer/main.go
+++ b/test/e2e/cmd/rabbitproducer/main.go
@@ -72,7 +72,9 @@ func main() {
 	var headers amqp.Table
 
 	for i := 0; i < env.Count; i++ {
-		if i < env.Count/3 {
+		switch i % 3 {
+		case 0:
+			contentType = "application/json"
 			headers = amqp.Table{
 				"ce-specversion":     "1.0",
 				"ce-id":              i,
@@ -81,7 +83,7 @@ func main() {
 				"ce-datacontenttype": "application/json; charset=UTF-8",
 			}
 			body = `{ "message": "Hello, BinCEWorld!" }`
-		} else if i < (env.Count/3)*2 {
+		case 1:
 			contentType = "application/cloudevents+json"
 			headers = amqp.Table{}
 			body = fmt.Sprintf(`{
@@ -91,10 +93,8 @@ func main() {
 				"data": "Hello, CEWorld!",
 				"specversion": "1.0",
 				"datacontenttype": "text/plain"
-			}`,
-				i,
-			)
-		} else {
+			}`, i)
+		case 2:
 			contentType = "text/plain"
 			headers = amqp.Table{}
 			body = fmt.Sprintf(`{ "id": %d, "message": "Hello, World!" }`, i)

--- a/test/e2e/config/sourceproducer/sourceproducer.go
+++ b/test/e2e/config/sourceproducer/sourceproducer.go
@@ -30,7 +30,7 @@ func init() {
 
 func Install() feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, map[string]interface{}{"producerCount": 5}); err != nil {
+		if _, err := manifest.InstallLocalYaml(ctx, map[string]interface{}{"producerCount": 10}); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/e2e/config/vhostsourceproducer/vhostsourceproducer.go
+++ b/test/e2e/config/vhostsourceproducer/vhostsourceproducer.go
@@ -30,7 +30,7 @@ func init() {
 
 func Install() feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, map[string]interface{}{"producerCount": 5}); err != nil {
+		if _, err := manifest.InstallLocalYaml(ctx, map[string]interface{}{"producerCount": 10}); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/e2e/source_test.go
+++ b/test/e2e/source_test.go
@@ -50,7 +50,7 @@ func DirectSourceTest() *feature.Feature {
 		Must("the recorder received all sent events within the time",
 			func(ctx context.Context, t feature.T) {
 				// TODO: Use constraint matching instead of just counting number of events.
-				eventshub.StoreFromContext(ctx, "recorder").AssertAtLeast(t, 5)
+				eventshub.StoreFromContext(ctx, "recorder").AssertAtLeast(t, 10)
 			})
 
 	return f

--- a/test/e2e/sourcevhost_test.go
+++ b/test/e2e/sourcevhost_test.go
@@ -51,7 +51,7 @@ func VHostSourceTest() *feature.Feature {
 		Must("the recorder received all sent events within the time",
 			func(ctx context.Context, t feature.T) {
 				// TODO: Use constraint matching instead of just counting number of events.
-				eventshub.StoreFromContext(ctx, "recorder").AssertAtLeast(t, 5)
+				eventshub.StoreFromContext(ctx, "recorder").AssertAtLeast(t, 10)
 			})
 
 	return f

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/test/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/test/doc.go
@@ -1,0 +1,4 @@
+/*
+Package test provides utilities to test binding implementations and transformers.
+*/
+package test

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_binary_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_binary_message.go
@@ -1,0 +1,129 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/spec"
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+// MockBinaryMessage implements a binary-mode message as a simple struct.
+// MockBinaryMessage implements both the binding.Message interface and the binding.BinaryWriter
+type MockBinaryMessage struct {
+	Version    spec.Version
+	Metadata   map[spec.Attribute]interface{}
+	Extensions map[string]interface{}
+	Body       []byte
+}
+
+// MustCreateMockBinaryMessage creates a new MockBinaryMessage starting from an event.Event. Panics in case of error
+func MustCreateMockBinaryMessage(e event.Event) binding.Message {
+	version := spec.VS.Version(e.SpecVersion())
+
+	m := MockBinaryMessage{
+		Version:    version,
+		Metadata:   make(map[spec.Attribute]interface{}),
+		Extensions: make(map[string]interface{}),
+	}
+
+	for _, attribute := range version.Attributes() {
+		val := attribute.Get(e.Context)
+		if val != nil {
+			m.Metadata[attribute] = val
+		}
+	}
+
+	for k, v := range e.Extensions() {
+		m.Extensions[k] = v
+	}
+
+	m.Body = e.Data()
+
+	return &m
+}
+
+func (bm *MockBinaryMessage) ReadEncoding() binding.Encoding {
+	return binding.EncodingBinary
+}
+
+func (bm *MockBinaryMessage) ReadStructured(context.Context, binding.StructuredWriter) error {
+	return binding.ErrNotStructured
+}
+
+func (bm *MockBinaryMessage) ReadBinary(ctx context.Context, b binding.BinaryWriter) error {
+	var err error
+	for k, v := range bm.Metadata {
+		err = b.SetAttribute(k, v)
+		if err != nil {
+			return err
+		}
+	}
+	for k, v := range bm.Extensions {
+		err = b.SetExtension(k, v)
+		if err != nil {
+			return err
+		}
+	}
+	if len(bm.Body) != 0 {
+		err = b.SetData(bytes.NewReader(bm.Body))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (bm *MockBinaryMessage) GetAttribute(k spec.Kind) (spec.Attribute, interface{}) {
+	a := bm.Version.AttributeFromKind(k)
+	if a != nil {
+		return a, bm.Metadata[a]
+	}
+	return nil, nil
+}
+
+func (bm *MockBinaryMessage) GetExtension(name string) interface{} {
+	return bm.Extensions[name]
+}
+
+func (bm *MockBinaryMessage) Finish(error) error { return nil }
+
+func (bm *MockBinaryMessage) Start(ctx context.Context) error {
+	bm.Metadata = make(map[spec.Attribute]interface{})
+	bm.Extensions = make(map[string]interface{})
+	return nil
+}
+
+func (bm *MockBinaryMessage) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	if value == nil {
+		delete(bm.Metadata, attribute)
+		return nil
+	}
+	bm.Metadata[attribute] = value
+	return nil
+}
+
+func (bm *MockBinaryMessage) SetExtension(name string, value interface{}) error {
+	if value == nil {
+		delete(bm.Extensions, name)
+		return nil
+	}
+	bm.Extensions[name] = value
+	return nil
+}
+
+func (bm *MockBinaryMessage) SetData(data io.Reader) (err error) {
+	bm.Body, err = ioutil.ReadAll(data)
+	return err
+}
+
+func (bm *MockBinaryMessage) End(ctx context.Context) error {
+	return nil
+}
+
+var _ binding.Message = (*MockBinaryMessage)(nil)
+var _ binding.MessageMetadataReader = (*MockBinaryMessage)(nil)
+var _ binding.BinaryWriter = (*MockBinaryMessage)(nil)

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_structured_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_structured_message.go
@@ -1,0 +1,56 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/format"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/cloudevents/sdk-go/v2/test"
+)
+
+// MockStructuredMessage implements a structured-mode message as a simple struct.
+// MockStructuredMessage implements both the binding.Message interface and the binding.StructuredWriter
+type MockStructuredMessage struct {
+	Format format.Format
+	Bytes  []byte
+}
+
+// MustCreateMockStructuredMessage creates a new MockStructuredMessage starting from an event.Event. Panics in case of error.
+func MustCreateMockStructuredMessage(t testing.TB, e event.Event) binding.Message {
+	return &MockStructuredMessage{
+		Bytes:  test.MustJSON(t, e),
+		Format: format.JSON,
+	}
+}
+
+func (s *MockStructuredMessage) ReadStructured(ctx context.Context, b binding.StructuredWriter) error {
+	return b.SetStructuredEvent(ctx, s.Format, bytes.NewReader(s.Bytes))
+}
+
+func (s *MockStructuredMessage) ReadBinary(context.Context, binding.BinaryWriter) error {
+	return binding.ErrNotBinary
+}
+
+func (s *MockStructuredMessage) ReadEncoding() binding.Encoding {
+	return binding.EncodingStructured
+}
+
+func (s *MockStructuredMessage) Finish(error) error { return nil }
+
+func (s *MockStructuredMessage) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) (err error) {
+	s.Format = format
+	s.Bytes, err = ioutil.ReadAll(event)
+	if err != nil {
+		return
+	}
+
+	return nil
+}
+
+var _ binding.Message = (*MockStructuredMessage)(nil)
+var _ binding.StructuredWriter = (*MockStructuredMessage)(nil)

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_transformer.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_transformer.go
@@ -1,0 +1,29 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+)
+
+type MockTransformer struct {
+	Invoked int
+}
+
+func (m *MockTransformer) Transform(binding.MessageMetadataReader, binding.MessageMetadataWriter) error {
+	m.Invoked++
+	return nil
+}
+
+var _ binding.Transformer = (*MockTransformer)(nil)
+
+func AssertTransformerInvokedOneTime(t *testing.T, m *MockTransformer) {
+	require.Equal(t,
+		1,
+		m.Invoked,
+		"Transformer must be invoked one time, while it was invoked %d",
+		m.Invoked,
+	)
+}

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_unknown_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/test/mock_unknown_message.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"context"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+)
+
+type unknownMessage struct{}
+
+func (u unknownMessage) ReadEncoding() binding.Encoding {
+	return binding.EncodingUnknown
+}
+
+func (u unknownMessage) ReadStructured(context.Context, binding.StructuredWriter) error {
+	return binding.ErrNotStructured
+}
+
+func (u unknownMessage) ReadBinary(context.Context, binding.BinaryWriter) error {
+	return binding.ErrNotBinary
+}
+
+func (u unknownMessage) Finish(error) error {
+	return nil
+}
+
+var UnknownMessage binding.Message = unknownMessage{}

--- a/vendor/github.com/cloudevents/sdk-go/v2/binding/test/transformer.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/binding/test/transformer.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/cloudevents/sdk-go/v2/test"
+)
+
+type TransformerTestArgs struct {
+	Name         string
+	InputEvent   event.Event
+	InputMessage binding.Message
+	WantEvent    event.Event
+	AssertFunc   func(t *testing.T, event event.Event)
+	Transformers []binding.Transformer
+}
+
+func RunTransformerTests(t *testing.T, ctx context.Context, tests []TransformerTestArgs) {
+	for _, tt := range tests {
+		tt := tt // Don't use range variable inside scope
+		t.Run(tt.Name, func(t *testing.T) {
+
+			var inputMessage binding.Message
+			if tt.InputMessage != nil {
+				inputMessage = tt.InputMessage
+			} else {
+				e := tt.InputEvent.Clone()
+				inputMessage = (*binding.EventMessage)(&e)
+			}
+
+			mockStructured := MockStructuredMessage{}
+			mockBinary := MockBinaryMessage{}
+
+			enc, err := binding.Write(ctx, inputMessage, &mockStructured, &mockBinary, tt.Transformers...)
+			require.NoError(t, err)
+
+			var e *event.Event
+			if enc == binding.EncodingStructured {
+				e, err = binding.ToEvent(ctx, &mockStructured)
+				require.NoError(t, err)
+			} else if enc == binding.EncodingBinary {
+				e, err = binding.ToEvent(ctx, &mockBinary)
+				require.NoError(t, err)
+			} else {
+				t.Fatalf("Unexpected encoding %v", enc)
+			}
+			require.NoError(t, err)
+			if tt.AssertFunc != nil {
+				tt.AssertFunc(t, *e)
+			} else {
+				test.AssertEventEquals(t, tt.WantEvent, *e)
+			}
+		})
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -51,6 +51,7 @@ github.com/cloudevents/sdk-go/v2
 github.com/cloudevents/sdk-go/v2/binding
 github.com/cloudevents/sdk-go/v2/binding/format
 github.com/cloudevents/sdk-go/v2/binding/spec
+github.com/cloudevents/sdk-go/v2/binding/test
 github.com/cloudevents/sdk-go/v2/client
 github.com/cloudevents/sdk-go/v2/context
 github.com/cloudevents/sdk-go/v2/event


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

It changes the Source to start correctly translating messages from its associated RabbitMQ Broker (RabbitMQ messages) to valid CloudEvents, based on the [RabbitMQ Protocol Binding Spec for CloudEvents defined in this repo.](https://github.com/knative-sandbox/eventing-rabbitmq/blob/main/cloudevents-protocol-spec/spec.md).

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Not re-wrapping cloud events when they are translated in the source (from a rabbitmq msg to a cloudevent)
- :gift: Include the message content type in the translation from msg to CE:
 case 1: If it is a cloud event that is stored on the broker, then use the cloudevent content-type
 case 2: If it is a non cloud event rabbitmq msg, use it's rabbitmq msg content type
 case 3: if there is no content type set in the msg, then leave it blank in the created cloud event
- :broom: Using helper functions from the CloudEvents library

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #367

**Release Note**

```release-note
:page_facing_up: The RabbitMQ Source now:
- translates RabbitMQ messages according to the [RabbitMQ Protocol Binding Spec for CloudEvents](https://github.com/knative-sandbox/eventing-rabbitmq/blob/main/cloudevents-protocol-spec/spec.md).  Falls back to RabbitMQ
- msg content type if it is not set on the CloudEvent data or headers.
- Avoids re-wrapping RabbitMQ messages that are already in the CloudEvent format
```
