### PR TITLE
Add predeclared behavior in RMQ Source

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -72,6 +72,7 @@ type adapterConfig struct {
 	User           string `envconfig:"RABBITMQ_USER" required:"false"`
 	Password       string `envconfig:"RABBITMQ_PASSWORD" required:"false"`
 	Vhost          string `envconfig:"RABBITMQ_VHOST" required:"false"`
+	Predeclared    bool   `envconfig:"RABBITMQ_PREDECLARED" required:"false"`
 	ChannelConfig  ChannelConfig
 	ExchangeConfig ExchangeConfig
 	QueueConfig    QueueConfig
@@ -187,6 +188,12 @@ func (a *Adapter) start(stopCh <-chan struct{}) error {
 
 func (a *Adapter) StartAmqpClient(ch *wabbit.Channel) (*wabbit.Queue, error) {
 	logger := a.logger
+
+	if a.config.Predeclared {
+		queue, err := (*ch).QueueInspect(a.config.QueueConfig.Name)
+		return &queue, err
+	}
+
 	exchangeConfig := fillDefaultValuesForExchangeConfig(&a.config.ExchangeConfig, a.config.Topic)
 
 	err := (*ch).ExchangeDeclare(

--- a/pkg/apis/sources/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_types.go
@@ -119,6 +119,11 @@ type RabbitmqSourceSpec struct {
 	// Password for rabbitmq connection
 	// +optional
 	Password SecretValueFromSource `json:"password,omitempty"`
+	// Predeclared defines if channels and queues are already predeclared and shouldn't be recreated.
+	// This should be used in case the user does not have permission to declare new queues and channels in
+	// RabbitMQ cluster
+	// +optional
+	Predeclared bool `json:"predeclared,omitempty"`
 	// ChannelConfig config for rabbitmq exchange
 	// +optional
 	ChannelConfig RabbitmqChannelConfigSpec `json:"channel_config,omitempty"`

--- a/pkg/reconciler/source/resources/receive_adapter.go
+++ b/pkg/reconciler/source/resources/receive_adapter.go
@@ -117,6 +117,10 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 			Value: strconv.FormatBool(args.Source.Spec.QueueConfig.NoWait),
 		},
 		{
+			Name:  "RABBITMQ_PREDECLARED",
+			Value: strconv.FormatBool(args.Source.Spec.Predeclared),
+		},
+		{
 			Name:  "SINK_URI",
 			Value: args.SinkURI,
 		},

--- a/pkg/reconciler/source/resources/receive_adapter_test.go
+++ b/pkg/reconciler/source/resources/receive_adapter_test.go
@@ -52,6 +52,7 @@ func TestMakeReceiveAdapter(t *testing.T) {
 					Key: "password",
 				},
 			},
+			Predeclared: true,
 			ExchangeConfig: v1alpha12.RabbitmqSourceExchangeConfigSpec{
 				Name:        "logs",
 				TypeOf:      "topic",
@@ -212,6 +213,10 @@ func TestMakeReceiveAdapter(t *testing.T) {
 								{
 									Name:  "RABBITMQ_QUEUE_CONFIG_NOWAIT",
 									Value: "false",
+								},
+								{
+									Name:  "RABBITMQ_PREDECLARED",
+									Value: "true",
 								},
 								{
 									Name:  "SINK_URI",

--- a/source/README.adoc
+++ b/source/README.adoc
@@ -71,6 +71,7 @@ Sources are Kubernetes objects. In addition to the standard Kubernetes
 
 | `spec.brokers` | Host+Port of the Broker, with a trailing "/"
 | `spec.vhost` | VHost where the source resources are located
+| `spec.predeclared` | Defines if adapter should try to create new queues or use predeclared one (Boolean)
 | `user.secretKeyRef` | Username for Broker authentication; field `key` in a Kubernetes Secret named `name`
 | `password.secretKeyRef` | Password for Broker authentication; field `key` in a Kubernetes Secret named `name`
 | `topic` | The topic for the exchange


### PR DESCRIPTION
Signed-off-by: Ricardo Katz <rkatz@vmware.com>


# Changes

This PR adds predeclared behavior in RMQ Source. This way, a user that only got permission to consume a specific queue still can use RabbitMQ Source, declaring the queue to be consumed.

Adapter will try to bind to that queue and get information of it, instead of going through the creation process of a new exchange, queue and binding that exchange to the queue.

/kind enhancement


Fixes #455


**Release Note**

```release-note
RabbitMQ source now can use predeclared queues instead of creating new ones
```

**Docs**


```docs

```
