### PR TITLE
Sink URI resolver tests update

### DIFF
--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 
 	"go.uber.org/zap"
@@ -65,6 +67,7 @@ func MakeFactory(ctor Ctor, unstructured bool, logger *zap.SugaredLogger) Factor
 		}
 		ctx = logging.WithLogger(ctx, logger)
 
+		ctx, _ = injection.Fake.SetupInformers(ctx, &rest.Config{})
 		ctx, kubeClient := fakekubeclient.With(ctx, ls.GetKubeObjects()...)
 		ctx, client := fakeeventingclient.With(ctx, ls.GetEventingObjects()...)
 		ctx, rabbitclient := fakerabbitclient.With(ctx, ls.GetRabbitObjects()...)

--- a/pkg/reconciler/trigger/controller_test.go
+++ b/pkg/reconciler/trigger/controller_test.go
@@ -35,6 +35,7 @@ import (
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/source/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
 

--- a/pkg/reconciler/triggerstandalone/controller_test.go
+++ b/pkg/reconciler/triggerstandalone/controller_test.go
@@ -34,6 +34,7 @@ import (
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/source/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
 


### PR DESCRIPTION
Sink resolver updated behavior introduced in knative/pkg#2322 requires `v1.Service` Informer injection to retrieve destination port details.

`v1.Service` informers manually injected and prepopulated with objects if they are required in the tests.