### PR TITLE
Hardcode broker class that the broker operates on

### DIFF
--- a/pkg/apis/eventing/v1/trigger_validation.go
+++ b/pkg/apis/eventing/v1/trigger_validation.go
@@ -28,7 +28,6 @@ import (
 	"knative.dev/pkg/kmp"
 )
 
-// TODO: This is technically variable, see https://github.com/knative-sandbox/eventing-rabbitmq/issues/466
 const BrokerClass = "RabbitMQBroker"
 
 func ValidateTrigger(ctx context.Context) func(context.Context, *unstructured.Unstructured) error {

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -60,10 +60,9 @@ type envConfig struct {
 
 	// Which image to use for the DeadLetter dispatcher
 	DispatcherImage string `envconfig:"BROKER_DLQ_DISPATCHER_IMAGE" required:"true"`
-
-	// The default value should match the cluster default in config/core/configmaps/default-broker.yaml
-	BrokerClass string `envconfig:"BROKER_CLASS" default:"RabbitMQBroker"`
 }
+
+const BrokerClass = "RabbitMQBroker"
 
 // NewController initializes the controller and is called by the generated code
 // Registers event handlers to enqueue events
@@ -101,13 +100,13 @@ func NewController(
 		rabbitLister:              rabbitInformer,
 		ingressImage:              env.IngressImage,
 		ingressServiceAccountName: env.IngressServiceAccount,
-		brokerClass:               env.BrokerClass,
+		brokerClass:               BrokerClass,
 		dispatcherImage:           env.DispatcherImage,
 		rabbitClientSet:           rabbitmqclient.Get(ctx),
 		rabbit:                    services.NewRabbit(ctx),
 	}
 
-	impl := brokerreconciler.NewImpl(ctx, r, env.BrokerClass)
+	impl := brokerreconciler.NewImpl(ctx, r, BrokerClass)
 
 	logging.FromContext(ctx).Info("Setting up event handlers")
 
@@ -116,7 +115,7 @@ func NewController(
 	r.uriResolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 
 	brokerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: pkgreconciler.AnnotationFilterFunc(brokerreconciler.ClassAnnotationKey, env.BrokerClass, false /*allowUnset*/),
+		FilterFunc: pkgreconciler.AnnotationFilterFunc(brokerreconciler.ClassAnnotationKey, BrokerClass, false /*allowUnset*/),
 		Handler:    controller.HandleAll(impl.Enqueue),
 	})
 

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -52,12 +52,11 @@ import (
 	"knative.dev/pkg/resolver"
 )
 
+const BrokerClass = "RabbitMQBroker"
+
 type envConfig struct {
 	DispatcherImage          string `envconfig:"BROKER_DISPATCHER_IMAGE" required:"true"`
 	DispatcherServiceAccount string `envconfig:"BROKER_DISPATCHER_SERVICE_ACCOUNT" required:"true"`
-
-	// The default value should match the cluster default in config/core/configmaps/default-broker.yaml
-	BrokerClass string `envconfig:"BROKER_CLASS" default:"RabbitMQBroker"`
 }
 
 // NewController initializes the controller and is called by the generated code
@@ -88,7 +87,7 @@ func NewController(
 		triggerLister:                triggerInformer.Lister(),
 		dispatcherImage:              env.DispatcherImage,
 		dispatcherServiceAccountName: env.DispatcherServiceAccount,
-		brokerClass:                  env.BrokerClass,
+		brokerClass:                  BrokerClass,
 		exchangeLister:               exchangeInformer.Lister(),
 		queueLister:                  queueInformer.Lister(),
 		bindingLister:                bindingInformer.Lister(),
@@ -146,7 +145,7 @@ func NewController(
 					log.Print("Failed to lookup Broker for Trigger", zap.Error(err))
 				} else {
 					label := broker.ObjectMeta.Annotations[brokerreconciler.ClassAnnotationKey]
-					if label == env.BrokerClass {
+					if label == BrokerClass {
 						impl.Enqueue(obj)
 					}
 				}


### PR DESCRIPTION
closes #466

# Changes

- :wastebasket: Do not  expose the broker class that the controller operates on as an environment variable.

/kind removal


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Do not  expose the broker class that the controller operates on as an environment variable.
```
