### PR TITLE
Remove ineffectual ctx assignment

### DIFF
--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -163,7 +163,6 @@ func (d *Dispatcher) dispatch(ctx context.Context, wg *sync.WaitGroup, queue <-c
 		if response != nil {
 			logging.FromContext(ctx).Infof("Sending an event: %+v", response)
 			ctx = cloudevents.ContextWithTarget(ctx, d.BrokerIngressURL)
-			cloudevents.ContextWithRetriesExponentialBackoff(ctx, d.BackoffDelay, d.MaxRetries)
 			result := ceClient.Send(ctx, *response)
 			if !isSuccess(ctx, result) {
 				logging.FromContext(ctx).Warnf("Failed to deliver to %q requeue: %v", d.BrokerIngressURL, d.Requeue)


### PR DESCRIPTION
This is a noop since we don't assign the context this function returns.
It likely was written here to reset the retry counter for retries to the
broker, but it also changes the strategy to exponential if the user was
using linear.

It's not really clear if we should be resetting the retry counter at
all, the semantics of this are vague, so for now let's just remove this.

Fixes #523