### PR TITLE
Use policies for broker/trigger queue creation

### DIFF
--- a/config/broker/200-rabbitmq-broker-clusterrole.yaml
+++ b/config/broker/200-rabbitmq-broker-clusterrole.yaml
@@ -52,6 +52,7 @@ rules:
     - bindings
     - exchanges
     - queues
+    - policies
     verbs:
     - "get"
     - "list"

--- a/pkg/reconciler/trigger/resources/queue_test.go
+++ b/pkg/reconciler/trigger/resources/queue_test.go
@@ -23,10 +23,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/eventing-rabbitmq/pkg/reconciler/trigger/resources"
 	rabbitv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
-	"knative.dev/pkg/ptr"
 )
 
 const (
@@ -99,34 +97,6 @@ func TestNewQueue(t *testing.T) {
 						Name:      rabbitmqcluster,
 						Namespace: "single-rabbitmq-cluster",
 					},
-				},
-			},
-		},
-		{
-			name: "adds a dead letter exchange if that is set",
-			args: &resources.QueueArgs{
-				Name:                triggerName,
-				Namespace:           namespace,
-				RabbitMQClusterName: rabbitmqcluster,
-				Owner:               owner,
-				Labels:              map[string]string{"cool": "label"},
-				DLXName:             ptr.String("dlx"),
-			},
-			want: &rabbitv1beta1.Queue{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            triggerName,
-					Namespace:       namespace,
-					OwnerReferences: []metav1.OwnerReference{owner},
-					Labels:          map[string]string{"cool": "label"},
-				},
-				Spec: rabbitv1beta1.QueueSpec{
-					Name:       triggerName,
-					Durable:    true,
-					AutoDelete: false,
-					RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
-						Name: rabbitmqcluster,
-					},
-					Arguments: &runtime.RawExtension{Raw: []byte(`{"x-dead-letter-exchange":"dlx"}`)},
 				},
 			},
 		},

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -251,8 +251,9 @@ func TestReconcile(t *testing.T) {
 				ReadyBroker(),
 				triggerWithFilter(),
 				createSecret(rabbitURL),
-				createReadyQueue(),
-				createReadyBinding(true),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(true)),
 			},
 			WantCreates: []runtime.Object{
 				createDispatcherDeployment(),
@@ -270,6 +271,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantCreates: []runtime.Object{
 				createQueue(),
+				createPolicy(true),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: triggerWithQueueNotReady(),
@@ -302,7 +304,8 @@ func TestReconcile(t *testing.T) {
 				ReadyBroker(),
 				triggerWithFilter(),
 				createSecret(rabbitURL),
-				createReadyQueue(),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
 			},
 			WantCreates: []runtime.Object{
 				createBinding(true),
@@ -317,7 +320,8 @@ func TestReconcile(t *testing.T) {
 				ReadyBroker(),
 				triggerWithFilter(),
 				createSecret(rabbitURL),
-				createReadyQueue(),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
 			},
 			WithReactors: []clientgotesting.ReactionFunc{
 				InduceFailure("create", "bindings"),
@@ -339,8 +343,9 @@ func TestReconcile(t *testing.T) {
 				ReadyBroker(),
 				triggerWithFilter(),
 				createSecret(rabbitURL),
-				createReadyQueue(),
-				createReadyBinding(true),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(true)),
 			},
 			WantCreates: []runtime.Object{
 				createDispatcherDeployment(),
@@ -354,8 +359,9 @@ func TestReconcile(t *testing.T) {
 			Objects: []runtime.Object{
 				ReadyBroker(),
 				makeSubscriberAddressableAsUnstructured(),
-				createReadyQueue(),
-				createReadyBinding(false),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(false)),
 				NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
 					WithTriggerSubscriberRef(subscriberGVK, subscriberName, testNS)),
@@ -381,8 +387,9 @@ func TestReconcile(t *testing.T) {
 			Objects: []runtime.Object{
 				ReadyBroker(),
 				makeSubscriberNotAddressableAsUnstructured(),
-				createReadyQueue(),
-				createReadyBinding(false),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(false)),
 				NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
 					WithTriggerSubscriberRef(subscriberGVK, subscriberName, testNS)),
@@ -411,8 +418,9 @@ func TestReconcile(t *testing.T) {
 					WithTriggerUID(triggerUID),
 					WithTriggerSubscriberURI(subscriberURI)),
 				createSecret(rabbitURL),
-				createReadyQueue(),
-				createReadyBinding(false),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(false)),
 			},
 			WithReactors: []clientgotesting.ReactionFunc{
 				InduceFailure("create", "deployments"),
@@ -446,8 +454,9 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberURI(subscriberURI)),
 				createSecret(rabbitURL),
 				createDifferentDispatcherDeployment(),
-				createReadyQueue(),
-				createReadyBinding(false),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(false)),
 			},
 			WithReactors: []clientgotesting.ReactionFunc{
 				InduceFailure("update", "deployments"),
@@ -480,8 +489,9 @@ func TestReconcile(t *testing.T) {
 					WithTriggerUID(triggerUID),
 					WithTriggerSubscriberURI(subscriberURI)),
 				createSecret(rabbitURL),
-				createReadyQueue(),
-				createReadyBinding(false),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(false)),
 				createDispatcherDeployment(),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -503,8 +513,9 @@ func TestReconcile(t *testing.T) {
 				ReadyBroker(),
 				triggerWithFilter(),
 				createSecret(rabbitURL),
-				createReadyQueue(),
-				createReadyBinding(true),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(true)),
 				createDispatcherDeployment(),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -521,8 +532,9 @@ func TestReconcile(t *testing.T) {
 					WithInitTriggerConditions,
 					WithDependencyAnnotation(dependencyAnnotation),
 				),
-				createReadyQueue(),
-				createReadyBinding(false),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(false)),
 			},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeWarning, "InternalError", "propagating dependency readiness: getting the dependency: pingsources.sources.knative.dev \"test-ping-source\" not found"),
@@ -552,8 +564,9 @@ func TestReconcile(t *testing.T) {
 					WithDependencyAnnotation(dependencyAnnotation),
 				),
 				createSecret(rabbitURL),
-				createReadyQueue(),
-				createReadyBinding(false),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(false)),
 			},
 			WantErr: false,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -580,8 +593,9 @@ func TestReconcile(t *testing.T) {
 					WithDependencyAnnotation(dependencyAnnotation),
 				),
 				createSecret(rabbitURL),
-				createReadyQueue(),
-				createReadyBinding(false),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(false)),
 			},
 			WantErr: false,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -608,8 +622,9 @@ func TestReconcile(t *testing.T) {
 					WithDependencyAnnotation(dependencyAnnotation),
 				),
 				createSecret(rabbitURL),
-				createReadyQueue(),
-				createReadyBinding(false),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(false)),
 			},
 			WantErr: false,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -634,8 +649,9 @@ func TestReconcile(t *testing.T) {
 					WithDependencyAnnotation(malformedDependencyAnnotation),
 				),
 				createSecret(rabbitURL),
-				createReadyQueue(),
-				createReadyBinding(false),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(false)),
 			},
 			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -664,8 +680,9 @@ func TestReconcile(t *testing.T) {
 					WithDependencyAnnotation(dependencyAnnotation),
 				),
 				createSecret(rabbitURL),
-				createReadyQueue(),
-				createReadyBinding(false),
+				markReady(createQueue()),
+				markReady(createPolicy(true)),
+				markReady(createBinding(false)),
 			},
 			WantErr: false,
 			WantCreates: []runtime.Object{
@@ -1004,7 +1021,6 @@ func createQueue() *rabbitv1beta1.Queue {
 		"eventing.knative.dev/broker":  brokerName,
 		"eventing.knative.dev/trigger": triggerName,
 	}
-	b := ReadyBroker()
 	t := triggerWithFilter()
 	return &rabbitv1beta1.Queue{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1022,23 +1038,26 @@ func createQueue() *rabbitv1beta1.Queue {
 				Name:      rabbitMQBrokerName,
 				Namespace: testNS,
 			},
-			Arguments: &runtime.RawExtension{
-				Raw: []byte(`{"x-dead-letter-exchange":"` + naming.BrokerExchangeName(b, true) + `"}`),
-			},
 		},
 	}
 }
 
-func createReadyQueue() *rabbitv1beta1.Queue {
-	q := createQueue()
-	q.Status = rabbitv1beta1.QueueStatus{
-		Conditions: []rabbitv1beta1.Condition{
-			{
-				Status: corev1.ConditionTrue,
-			},
-		},
+func createPolicy(broker bool) *rabbitv1beta1.Policy {
+	t := triggerWithFilter()
+	var dlxName string
+	if broker {
+		dlxName = naming.BrokerExchangeName(ReadyBroker(), true)
+	} else {
+		dlxName = naming.TriggerDLXExchangeName(t)
 	}
-	return q
+	return resources.NewPolicy(&resources.QueueArgs{
+		Name:                     queueName,
+		Namespace:                testNS,
+		Owner:                    *kmeta.NewControllerRef(t),
+		DLXName:                  &dlxName,
+		RabbitMQClusterName:      rabbitMQBrokerName,
+		RabbitMQClusterNamespace: testNS,
+	})
 }
 
 func createBinding(withFilter bool) *rabbitv1beta1.Binding {
@@ -1072,19 +1091,6 @@ func createBinding(withFilter bool) *rabbitv1beta1.Binding {
 	}
 }
 
-func createReadyBinding(withFilter bool) *rabbitv1beta1.Binding {
-	b := createBinding(withFilter)
-	b.Status = rabbitv1beta1.BindingStatus{
-		Conditions: []rabbitv1beta1.Condition{
-			{
-				Status: corev1.ConditionTrue,
-			},
-		},
-	}
-	return b
-
-}
-
 func getTriggerArguments(withFilter bool) *runtime.RawExtension {
 	arguments := map[string]string{
 		"x-knative-trigger": triggerName,
@@ -1100,4 +1106,21 @@ func getTriggerArguments(withFilter bool) *runtime.RawExtension {
 	return &runtime.RawExtension{
 		Raw: argumentsJson,
 	}
+}
+
+func markReady(r runtime.Object) runtime.Object {
+	ready := rabbitv1beta1.Condition{Status: corev1.ConditionTrue}
+	switch v := r.(type) {
+	case *rabbitv1beta1.Binding:
+		v.Status.Conditions = append(v.Status.Conditions, ready)
+	case *rabbitv1beta1.Exchange:
+		v.Status.Conditions = append(v.Status.Conditions, ready)
+	case *rabbitv1beta1.Queue:
+		v.Status.Conditions = append(v.Status.Conditions, ready)
+	case *rabbitv1beta1.Policy:
+		v.Status.Conditions = append(v.Status.Conditions, ready)
+	default:
+		panic("unknown type")
+	}
+	return r
 }


### PR DESCRIPTION
# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Allow users to change the DLS on a trigger, which previously was not possible because queue properties are immutable

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #448

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
:page_facing_up: Removing the dead letter sink on a trigger will now properly fall back to the broker's dead letter sink, if one is defined
```

