### PR TITLE
Add securityContext to Knative Eventing RabbitMQ objects

### DIFF
--- a/config/broker/500-broker-controller.yaml
+++ b/config/broker/500-broker-controller.yaml
@@ -71,6 +71,11 @@ spec:
             value:
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - all
         ports:
         - name: metrics
           containerPort: 9090

--- a/config/broker/500-webhook.yaml
+++ b/config/broker/500-webhook.yaml
@@ -76,6 +76,11 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - all
 
         ports:
         - name: https-webhook

--- a/config/brokerstandalone/500-broker-controller.yaml
+++ b/config/brokerstandalone/500-broker-controller.yaml
@@ -71,6 +71,11 @@ spec:
             value:
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - all
         ports:
         - name: metrics
           containerPort: 9090

--- a/config/brokerstandalone/500-webhook.yaml
+++ b/config/brokerstandalone/500-webhook.yaml
@@ -76,6 +76,11 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - all
 
         ports:
         - name: https-webhook

--- a/config/source/500-controller.yaml
+++ b/config/source/500-controller.yaml
@@ -45,6 +45,13 @@ spec:
               value: config-observability
             - name: RABBITMQ_RA_IMAGE
               value: ko://knative.dev/eventing-rabbitmq/cmd/receive_adapter
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - all
           volumeMounts:
           resources:
             limits:

--- a/config/source/500-webhook.yaml
+++ b/config/source/500-webhook.yaml
@@ -76,6 +76,11 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - all
 
         ports:
         - name: https-webhook


### PR DESCRIPTION

# Changes

🧹 All eventing-rabbitmq pods are run with a restricted pod security standard profile

Fixes #496

See also: https://github.com/knative/eventing/pull/5863

**Release Note**

```release-note
All core Knative Eventing RabbitMQ Pods should now be able to run in the restricted pod security standard profile.
```

**Docs**


```docs
n/a
```
