### PR TITLE
Refactor rabbit service to return Results

### DIFF
--- a/pkg/rabbit/service.go
+++ b/pkg/rabbit/service.go
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package services
+package rabbit
 
 import (
 	"context"
 	"fmt"
 
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +37,7 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-func NewRabbit(ctx context.Context) *Rabbit {
+func New(ctx context.Context) *Rabbit {
 	return &Rabbit{
 		rabbitClientSet: rabbitmqclient.Get(ctx),
 		exchangeLister:  exchangeinformer.Get(ctx).Lister(),
@@ -45,7 +46,7 @@ func NewRabbit(ctx context.Context) *Rabbit {
 	}
 }
 
-func NewRabbitTest(
+func NewTest(
 	rabbitClientSet rabbitclientset.Interface,
 	exchangeLister rabbitlisters.ExchangeLister,
 	queueLister rabbitlisters.QueueLister,
@@ -60,6 +61,8 @@ func NewRabbitTest(
 	}
 }
 
+var _ Service = (*Rabbit)(nil)
+
 type Rabbit struct {
 	rabbitClientSet rabbitclientset.Interface
 	exchangeLister  rabbitlisters.ExchangeLister
@@ -67,26 +70,32 @@ type Rabbit struct {
 	bindingLister   rabbitlisters.BindingLister
 }
 
-func (r *Rabbit) ReconcileExchange(ctx context.Context, args *resources.ExchangeArgs) (*v1beta1.Exchange, error) {
+func (r *Rabbit) ReconcileExchange(ctx context.Context, args *resources.ExchangeArgs) (Result, error) {
 	logging.FromContext(ctx).Infow("Reconciling exchange", zap.String("name", args.Name))
 
 	want := resources.NewExchange(ctx, args)
 	current, err := r.exchangeLister.Exchanges(args.Broker.Namespace).Get(args.Name)
 	if apierrs.IsNotFound(err) {
 		logging.FromContext(ctx).Debugw("Creating rabbitmq exchange", zap.String("exchange name", want.Name))
-		return r.rabbitClientSet.RabbitmqV1beta1().Exchanges(args.Broker.Namespace).Create(ctx, want, metav1.CreateOptions{})
+		current, err = r.rabbitClientSet.RabbitmqV1beta1().Exchanges(args.Broker.Namespace).Create(ctx, want, metav1.CreateOptions{})
 	} else if err != nil {
-		return nil, err
+		return Result{}, err
 	} else if !equality.Semantic.DeepDerivative(want.Spec, current.Spec) {
 		// Don't modify the informers copy.
 		desired := current.DeepCopy()
 		desired.Spec = want.Spec
-		return r.rabbitClientSet.RabbitmqV1beta1().Exchanges(args.Broker.Namespace).Update(ctx, desired, metav1.UpdateOptions{})
+		current, err = r.rabbitClientSet.RabbitmqV1beta1().Exchanges(args.Broker.Namespace).Update(ctx, desired, metav1.UpdateOptions{})
 	}
-	return current, nil
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Name:  want.Name,
+		Ready: isReady(current.Status.Conditions),
+	}, nil
 }
 
-func (r *Rabbit) ReconcileQueue(ctx context.Context, args *triggerresources.QueueArgs) (*v1beta1.Queue, error) {
+func (r *Rabbit) ReconcileQueue(ctx context.Context, args *triggerresources.QueueArgs) (Result, error) {
 	logging.FromContext(ctx).Info("Reconciling queue")
 
 	queueName := args.Name
@@ -94,36 +103,62 @@ func (r *Rabbit) ReconcileQueue(ctx context.Context, args *triggerresources.Queu
 	current, err := r.queueLister.Queues(args.Namespace).Get(queueName)
 	if apierrs.IsNotFound(err) {
 		logging.FromContext(ctx).Debugw("Creating rabbitmq exchange", zap.String("queue name", want.Name))
-		return r.rabbitClientSet.RabbitmqV1beta1().Queues(args.Namespace).Create(ctx, want, metav1.CreateOptions{})
+		current, err = r.rabbitClientSet.RabbitmqV1beta1().Queues(args.Namespace).Create(ctx, want, metav1.CreateOptions{})
 	} else if err != nil {
-		return nil, err
+		return Result{}, err
 	} else if !equality.Semantic.DeepDerivative(want.Spec, current.Spec) {
 		// Don't modify the informers copy.
 		desired := current.DeepCopy()
 		desired.Spec = want.Spec
-		return r.rabbitClientSet.RabbitmqV1beta1().Queues(args.Namespace).Update(ctx, desired, metav1.UpdateOptions{})
+		current, err = r.rabbitClientSet.RabbitmqV1beta1().Queues(args.Namespace).Update(ctx, desired, metav1.UpdateOptions{})
 	}
-	return current, nil
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Name:  want.Name,
+		Ready: isReady(current.Status.Conditions),
+	}, nil
 }
 
-func (r *Rabbit) ReconcileBinding(ctx context.Context, args *triggerresources.BindingArgs) (*v1beta1.Binding, error) {
+func (r *Rabbit) ReconcileBinding(ctx context.Context, args *triggerresources.BindingArgs) (Result, error) {
 	logging.FromContext(ctx).Info("Reconciling binding")
 
 	want, err := triggerresources.NewBinding(ctx, args)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create the binding spec: %w", err)
+		return Result{}, fmt.Errorf("failed to create the binding spec: %w", err)
 	}
 	current, err := r.bindingLister.Bindings(args.Namespace).Get(args.Name)
 	if apierrs.IsNotFound(err) {
 		logging.FromContext(ctx).Infow("Creating rabbitmq binding", zap.String("binding name", want.Name))
-		return r.rabbitClientSet.RabbitmqV1beta1().Bindings(args.Namespace).Create(ctx, want, metav1.CreateOptions{})
+		current, err = r.rabbitClientSet.RabbitmqV1beta1().Bindings(args.Namespace).Create(ctx, want, metav1.CreateOptions{})
 	} else if err != nil {
-		return nil, err
+		return Result{}, err
 	} else if !equality.Semantic.DeepDerivative(want.Spec, current.Spec) {
 		// Don't modify the informers copy.
 		desired := current.DeepCopy()
 		desired.Spec = want.Spec
-		return r.rabbitClientSet.RabbitmqV1beta1().Bindings(args.Namespace).Update(ctx, desired, metav1.UpdateOptions{})
+		current, err = r.rabbitClientSet.RabbitmqV1beta1().Bindings(args.Namespace).Update(ctx, desired, metav1.UpdateOptions{})
 	}
-	return current, nil
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Name:  want.Name,
+		Ready: isReady(current.Status.Conditions),
+	}, nil
+}
+
+func isReady(conditions []v1beta1.Condition) bool {
+	numConditions := len(conditions)
+	// If there are no conditions at all, the resource probably hasn't been reconciled yet => not ready
+	if numConditions == 0 {
+		return false
+	}
+	for _, c := range conditions {
+		if c.Status == corev1.ConditionTrue {
+			numConditions--
+		}
+	}
+	return numConditions == 0
 }

--- a/pkg/rabbit/types.go
+++ b/pkg/rabbit/types.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rabbit
+
+import (
+	"context"
+
+	"knative.dev/eventing-rabbitmq/pkg/reconciler/broker/resources"
+	triggerresources "knative.dev/eventing-rabbitmq/pkg/reconciler/trigger/resources"
+)
+
+type Result struct {
+	Name  string
+	Ready bool
+}
+
+type Service interface {
+	ReconcileExchange(context.Context, *resources.ExchangeArgs) (Result, error)
+	ReconcileQueue(context.Context, *triggerresources.QueueArgs) (Result, error)
+	ReconcileBinding(context.Context, *triggerresources.BindingArgs) (Result, error)
+}

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -141,7 +141,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *eventingv1.Broker) pk
 		MarkExchangeFailed(&b.Status, "ReconcileFailure", "using secret is not supported with this controller")
 		return nil
 	}
-	args.RabbitMQClusterName = b.Spec.Config.Name
 	return r.reconcileUsingCRD(ctx, b, args)
 }
 

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -1014,7 +1014,7 @@ func TestReconcile(t *testing.T) {
 			dispatcherImage:    dispatcherImage,
 			rabbitClientSet:    fakerabbitclient.Get(ctx),
 			rabbitLister:       rabbitduck.Get(ctx),
-			rabbit:             rabbit.NewTest(fakerabbitclient.Get(ctx), listers.GetExchangeLister(), listers.GetQueueLister(), listers.GetBindingLister()),
+			rabbit:             rabbit.New(ctx),
 		}
 		return broker.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetBrokerLister(),

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -33,8 +33,8 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	rabbitmqduck "knative.dev/eventing-rabbitmq/pkg/apis/duck/v1beta1"
 	rabbitduck "knative.dev/eventing-rabbitmq/pkg/client/injection/ducks/duck/v1beta1/rabbit"
+	"knative.dev/eventing-rabbitmq/pkg/rabbit"
 	"knative.dev/eventing-rabbitmq/pkg/reconciler/broker/resources"
-	"knative.dev/eventing-rabbitmq/pkg/reconciler/services"
 	rabbitv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 	fakerabbitclient "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/client/fake"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
@@ -1014,7 +1014,7 @@ func TestReconcile(t *testing.T) {
 			dispatcherImage:    dispatcherImage,
 			rabbitClientSet:    fakerabbitclient.Get(ctx),
 			rabbitLister:       rabbitduck.Get(ctx),
-			rabbit:             services.NewRabbitTest(fakerabbitclient.Get(ctx), listers.GetExchangeLister(), listers.GetQueueLister(), listers.GetBindingLister()),
+			rabbit:             rabbit.NewTest(fakerabbitclient.Get(ctx), listers.GetExchangeLister(), listers.GetQueueLister(), listers.GetBindingLister()),
 		}
 		return broker.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetBrokerLister(),

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"log"
 
-	"knative.dev/eventing-rabbitmq/pkg/client/injection/ducks/duck/v1beta1/rabbit"
-	"knative.dev/eventing-rabbitmq/pkg/reconciler/services"
+	rabbitv1 "knative.dev/eventing-rabbitmq/pkg/client/injection/ducks/duck/v1beta1/rabbit"
+	"knative.dev/eventing-rabbitmq/pkg/rabbit"
 	"knative.dev/eventing-rabbitmq/pkg/utils"
 	rabbitmqclient "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/client"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
@@ -90,7 +90,7 @@ func NewController(
 	brokerInformer := brokerinformer.Get(ctx)
 	serviceInformer := serviceinformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)
-	rabbitInformer := rabbit.Get(ctx)
+	rabbitInformer := rabbitv1.Get(ctx)
 	exchangeInformer := exchangeinformer.Get(ctx)
 	queueInformer := queueinformer.Get(ctx)
 	bindingInformer := bindinginformer.Get(ctx)
@@ -111,8 +111,8 @@ func NewController(
 		brokerClass:               BrokerClass,
 		dispatcherImage:           env.DispatcherImage,
 		rabbitClientSet:           rabbitmqclient.Get(ctx),
-		rabbit:                    services.NewRabbit(ctx),
 		configs:                   reconcilersource.WatchConfigurations(ctx, ComponentName, cmw),
+		rabbit:                    rabbit.New(ctx),
 	}
 
 	impl := brokerreconciler.NewImpl(ctx, r, BrokerClass)

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"log"
 
-	"knative.dev/eventing-rabbitmq/pkg/reconciler/services"
+	"knative.dev/eventing-rabbitmq/pkg/rabbit"
 	"knative.dev/eventing-rabbitmq/pkg/utils"
 	rabbitmqclient "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/client"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
@@ -99,8 +99,8 @@ func NewController(
 		queueLister:                  queueInformer.Lister(),
 		bindingLister:                bindingInformer.Lister(),
 		rabbitClientSet:              rabbitmqclient.Get(ctx),
-		rabbit:                       services.NewRabbit(ctx),
 		configs:                      reconcilersource.WatchConfigurations(ctx, component, cmw),
+		rabbit:                       rabbit.New(ctx),
 	}
 
 	impl := triggerreconciler.NewImpl(ctx, r)

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -38,9 +38,9 @@ import (
 
 	clientgotesting "k8s.io/client-go/testing"
 	rabbitduck "knative.dev/eventing-rabbitmq/pkg/client/injection/ducks/duck/v1beta1/rabbit"
+	"knative.dev/eventing-rabbitmq/pkg/rabbit"
 	naming "knative.dev/eventing-rabbitmq/pkg/rabbitmqnaming"
 	"knative.dev/eventing-rabbitmq/pkg/reconciler/broker"
-	"knative.dev/eventing-rabbitmq/pkg/reconciler/services"
 	"knative.dev/eventing-rabbitmq/pkg/reconciler/trigger/resources"
 	rabbitv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 	fakerabbitclient "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/client/fake"
@@ -711,7 +711,7 @@ func TestReconcile(t *testing.T) {
 			rabbitClientSet:    fakerabbitclient.Get(ctx),
 			queueLister:        listers.GetQueueLister(),
 			bindingLister:      listers.GetBindingLister(),
-			rabbit:             services.NewRabbitTest(fakerabbitclient.Get(ctx), listers.GetExchangeLister(), listers.GetQueueLister(), listers.GetBindingLister()),
+			rabbit:             rabbit.NewTest(fakerabbitclient.Get(ctx), listers.GetExchangeLister(), listers.GetQueueLister(), listers.GetBindingLister()),
 		}
 		return trigger.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetTriggerLister(),

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -711,7 +711,7 @@ func TestReconcile(t *testing.T) {
 			rabbitClientSet:    fakerabbitclient.Get(ctx),
 			queueLister:        listers.GetQueueLister(),
 			bindingLister:      listers.GetBindingLister(),
-			rabbit:             rabbit.NewTest(fakerabbitclient.Get(ctx), listers.GetExchangeLister(), listers.GetQueueLister(), listers.GetBindingLister()),
+			rabbit:             rabbit.New(ctx),
 		}
 		return trigger.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetTriggerLister(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :wastebasket: Remove feature or internal logic
-->

- :broom: Change the contract of the RabbitService interface to return `Result` objects rather than the CRD
- :broom: Remove exchange, binding, and queue informers and just use the rabbitmq typed client to do CRUD operations from within the RabbitService

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup

Requested to be split out of #533 by @ikvmw