### PR TITLE
Fixing workflow errors

### DIFF
--- a/.github/workflows/kind-conformance-standalone.yaml
+++ b/.github/workflows/kind-conformance-standalone.yaml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.20.7
         - v1.21.2
         - v1.22.1
 
@@ -27,8 +26,6 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.0
         include:
-        - k8s-version: v1.20.7
-          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
         - k8s-version: v1.21.2
           kind-image-sha: sha256:0fda882e43d425622f045b492f8bd83c2e0b4984fc03e2e05ec101ca1a685fb7
         - k8s-version: v1.22.1
@@ -67,6 +64,7 @@ jobs:
 
     - name: Gather Failure Data
       if: ${{ failure() }}
+      working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       run: |
         set -x
         make .env

--- a/.github/workflows/kind-conformance.yaml
+++ b/.github/workflows/kind-conformance.yaml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.20.7
         - v1.21.2
         - v1.22.1
 
@@ -27,8 +26,6 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
         include:
-        - k8s-version: v1.20.7
-          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
         - k8s-version: v1.21.2
           kind-image-sha: sha256:0fda882e43d425622f045b492f8bd83c2e0b4984fc03e2e05ec101ca1a685fb7
         - k8s-version: v1.22.1
@@ -67,6 +64,7 @@ jobs:
 
     - name: Gather Failure Data
       if: ${{ failure() }}
+      working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       run: |
         set -x
         make .env

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -19,7 +19,7 @@ jobs:
         - v1.22.1
 
         knative-version:
-        - 1.0.3
+        - 1.0.2
         - 1.1.0
 
         # Map between K8s and KinD versions.

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -15,20 +15,17 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.20.7
         - v1.21.2
         - v1.22.1
 
         knative-version:
-        - 1.0.0
+        - 1.0.3
         - 1.1.0
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
         include:
-        - k8s-version: v1.20.7
-          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
         - k8s-version: v1.21.2
           kind-image-sha: sha256:0fda882e43d425622f045b492f8bd83c2e0b4984fc03e2e05ec101ca1a685fb7
         - k8s-version: v1.22.1

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ releases-envsubst:
 
 KUBECTL_RELEASES := https://github.com/kubernetes/kubernetes/tags
 # Keep this in sync with KIND_K8S_VERSION
-KUBECTL_VERSION := 1.20.7
+KUBECTL_VERSION := 1.21.9
 KUBECTL_BIN := kubectl-$(KUBECTL_VERSION)-$(platform)-amd64
 KUBECTL_URL := https://storage.googleapis.com/kubernetes-release/release/v$(KUBECTL_VERSION)/bin/$(platform)/amd64/kubectl
 KUBECTL := $(LOCAL_BIN)/$(KUBECTL_BIN)
@@ -282,7 +282,7 @@ KO_DOCKER_REPO := kind.local
 env::
 	@echo 'export KO_DOCKER_REPO="$(KO_DOCKER_REPO)"'
 export KO_DOCKER_REPO
-MIN_SUPPORTED_K8S_VERSION := 1.20
+MIN_SUPPORTED_K8S_VERSION := 1.21
 KIND_K8S_VERSION ?= $(MIN_SUPPORTED_K8S_VERSION)
 export KIND_K8S_VERSION
 # Find the corresponding version digest in https://github.com/kubernetes-sigs/kind/releases


### PR DESCRIPTION
- removed k8s v1.20 cause is not compatible with knative 1.1.0+
- added working directory to failure conformance workflows step
