### PR TITLE
Modifies broker address to match other brokers (InMemory, Kafka)

### DIFF
--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -366,6 +366,7 @@ func (r *Reconciler) reconcileCommonIngressResources(ctx context.Context, s *cor
 	SetAddress(&b.Status, &apis.URL{
 		Scheme: "http",
 		Host:   network.GetServiceHostname(ingressEndpoints.GetName(), ingressEndpoints.GetNamespace()),
+		Path:   fmt.Sprintf("/%s/%s", b.Namespace, b.Name),
 	})
 
 	// If there's a Dead Letter Sink, then create a dispatcher for it. Note that this is for

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -97,6 +97,7 @@ var (
 	brokerAddress      = &apis.URL{
 		Scheme: "http",
 		Host:   network.GetServiceHostname(ingressServiceName, testNS),
+		Path:   fmt.Sprintf("/%s/%s", testNS, brokerName),
 	}
 	deadLetterSinkAddress = &apis.URL{
 		Scheme: "http",


### PR DESCRIPTION
# Changes
- :broom: Updates broker address URL to include a path with namespace and name


/kind cleanup

Fixes #585 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

```release-note
- Broker URLs updated to be `http://<broker-URL>/<namespace>/<broker-name>`
```
