### PR TITLE
Increases worker node count to 2 for e2e/conformance tests

### DIFF
--- a/test/e2e/kind.yaml
+++ b/test/e2e/kind.yaml
@@ -19,3 +19,5 @@ nodes:
   image: kindest/node:${KIND_K8S_VERSION}@${KIND_K8S_DIGEST}
 - role: worker
   image: kindest/node:${KIND_K8S_VERSION}@${KIND_K8S_DIGEST}
+- role: worker
+  image: kindest/node:${KIND_K8S_VERSION}@${KIND_K8S_DIGEST}


### PR DESCRIPTION
- the conformance tests were failing as the one worker node was reaching its max of 110 pods

/kind performance

Alleviates some of the cause of #588 

