### PR TITLE
Adds policyInformer to Trigger and Broker controllers

### DIFF
--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -36,6 +36,7 @@ import (
 
 	bindinginformer "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/binding"
 	exchangeinformer "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/exchange"
+	policyinformer "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/policy"
 	queueinformer "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/queue"
 	brokerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker"
 	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
@@ -92,6 +93,7 @@ func NewController(
 	endpointsInformer := endpointsinformer.Get(ctx)
 	rabbitInformer := rabbitv1.Get(ctx)
 	exchangeInformer := exchangeinformer.Get(ctx)
+	policyInformer := policyinformer.Get(ctx)
 	queueInformer := queueinformer.Get(ctx)
 	bindingInformer := bindinginformer.Get(ctx)
 	configmapInformer := configmapinformer.Get(ctx)
@@ -152,7 +154,10 @@ func NewController(
 		FilterFunc: controller.FilterControllerGK(eventingv1.Kind("Broker")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
-
+	policyInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterControllerGK(eventingv1.Kind("Broker")),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
 	queueInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterControllerGK(eventingv1.Kind("Broker")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),

--- a/pkg/reconciler/broker/controller_test.go
+++ b/pkg/reconciler/broker/controller_test.go
@@ -28,6 +28,7 @@ import (
 	_ "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/client/fake"
 	_ "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/binding/fake"
 	_ "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/exchange/fake"
+	_ "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/policy/fake"
 	_ "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/queue/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -47,6 +47,7 @@ import (
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
 
+	policyinformer "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/policy"
 	queueinformer "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/queue"
 
 	"knative.dev/pkg/configmap"
@@ -80,6 +81,7 @@ func NewController(
 	brokerInformer := brokerinformer.Get(ctx)
 	deploymentInformer := deploymentinformer.Get(ctx)
 	triggerInformer := triggerinformer.Get(ctx)
+	policyInformer := policyinformer.Get(ctx)
 	queueInformer := queueinformer.Get(ctx)
 	bindingInformer := bindinginformer.Get(ctx)
 	exchangeInformer := exchangeinformer.Get(ctx)
@@ -116,6 +118,10 @@ func NewController(
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 	queueInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterControllerGK(v1.Kind("Trigger")),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
+	policyInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterControllerGK(v1.Kind("Trigger")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})

--- a/pkg/reconciler/trigger/controller_test.go
+++ b/pkg/reconciler/trigger/controller_test.go
@@ -28,6 +28,7 @@ import (
 	_ "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/client/fake"
 	_ "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/binding/fake"
 	_ "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/exchange/fake"
+	_ "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/policy/fake"
 	_ "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/informers/rabbitmq.com/v1beta1/queue/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"

--- a/test/e2e/kind.yaml
+++ b/test/e2e/kind.yaml
@@ -19,5 +19,3 @@ nodes:
   image: kindest/node:${KIND_K8S_VERSION}@${KIND_K8S_DIGEST}
 - role: worker
   image: kindest/node:${KIND_K8S_VERSION}@${KIND_K8S_DIGEST}
-- role: worker
-  image: kindest/node:${KIND_K8S_VERSION}@${KIND_K8S_DIGEST}

--- a/test/e2e/kind.yaml
+++ b/test/e2e/kind.yaml
@@ -19,3 +19,5 @@ nodes:
   image: kindest/node:${KIND_K8S_VERSION}@${KIND_K8S_DIGEST}
 - role: worker
   image: kindest/node:${KIND_K8S_VERSION}@${KIND_K8S_DIGEST}
+- role: worker
+  image: kindest/node:${KIND_K8S_VERSION}@${KIND_K8S_DIGEST}


### PR DESCRIPTION
Observed a state where a Trigger can be in an unready state even though the Queue and Policy are both in Ready. 

# Changes
The trigger controller will now watch for events in policies and enqueue the trigger if it's the owner of the policy.
The broker controller will also watch for policies owned by Brokers


/kind bug


Addresses some of the flakes observed in #588  