### PR TITLE
Limit the resource request for rabbitmq cluster in conformance tests

### DIFF
--- a/test/conformance/resources/rabbitmqcluster/rabbitmqcluster.yaml
+++ b/test/conformance/resources/rabbitmqcluster/rabbitmqcluster.yaml
@@ -5,3 +5,10 @@ metadata:
   namespace: {{ .namespace }}
 spec:
   replicas: 1
+  resources:
+    limits:
+      cpu: "2000m"
+      memory: "500Mi"
+    requests:
+      cpu: "100m"
+      memory: "500Mi"


### PR DESCRIPTION
# Changes
- 🧹  set a cap on rabbitmq cluster resources

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

/kind cleanup

e2e tests already limit the resources.