### PR TITLE
[Docs] Adds trigger performance examples

### DIFF
--- a/broker/README.md
+++ b/broker/README.md
@@ -38,12 +38,10 @@ To get autoscaling (scale to zero as well as up from 0), you can also optionally
 install
 [KEDA based autoscaler](https://github.com/knative-sandbox/eventing-autoscaler-keda).
 
-## Trigger Customization (optional)
-The Trigger can be customized to better fit a user's needs. Check out the [Trigger-Customizations Samples Directory](../samples/trigger-customizations) for examples.
-
 ## Next Steps
 
-Check out the [Broker-Trigger Samples Directory](../samples/broker-trigger) in this repo and start building your topology with Eventing RabbitMQ!
+- Check out the [Broker-Trigger Samples Directory](../samples/broker-trigger) in this repo and start building your topology with Eventing RabbitMQ!
+- The Trigger can be customized to better fit a user's needs. Check out the [Trigger-Customizations Samples Directory](../samples/trigger-customizations) for examples.
 
 ## Additional Resources
 

--- a/broker/README.md
+++ b/broker/README.md
@@ -38,6 +38,9 @@ To get autoscaling (scale to zero as well as up from 0), you can also optionally
 install
 [KEDA based autoscaler](https://github.com/knative-sandbox/eventing-autoscaler-keda).
 
+## Trigger Customization (optional)
+The Trigger can be customized to better fit a user's needs. Check out the [Trigger-Customizations Samples Directory](../samples/trigger-customizations) for examples.
+
 ## Next Steps
 
 Check out the [Broker-Trigger Samples Directory](../samples/broker-trigger) in this repo and start building your topology with Eventing RabbitMQ!

--- a/broker/README.md
+++ b/broker/README.md
@@ -38,12 +38,24 @@ To get autoscaling (scale to zero as well as up from 0), you can also optionally
 install
 [KEDA based autoscaler](https://github.com/knative-sandbox/eventing-autoscaler-keda).
 
+## Trigger Pre-Fetch Count
+Trigger has a configurable annotation `rabbitmq.eventing.knative.dev/prefetchCount`. The following are effects of setting this parameter to `n`:
+
+- Prefetch count is set on the RabbitMQ channel and queue created for this trigger. The channel will receive a maximum of `n` number of messages at once.
+- The trigger will create `n` workers to consume messages off the queue and dispatch to the sink.
+
+If this value is unset, it will default to `1`. This means the trigger will only handle one event at a time. This will preserve the order of the messages in a queue but
+will make the trigger a bottleneck. A slow processing sink will result in low overall throughput. Setting a value higher than 1 will result in `n` events being handled at
+a time by the trigger but ordering won't be guaranteed as events are sent to the sink.
+
+More details and samples can be found [here](../samples/trigger-customizations)
+
 ## Next Steps
 
 - Check out the [Broker-Trigger Samples Directory](../samples/broker-trigger) in this repo and start building your topology with Eventing RabbitMQ!
-- The Trigger can be customized to better fit a user's needs. Check out the [Trigger-Customizations Samples Directory](../samples/trigger-customizations) for examples.
 
 ## Additional Resources
 
 - [RabbitMQ Docs](https://www.rabbitmq.com/documentation.html)
+- [RabbitMQ Operator Docs](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html)
 - [Knative Docs](https://knative.dev/docs/)

--- a/samples/trigger-customizations/100-namespace.yaml
+++ b/samples/trigger-customizations/100-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trigger-demo

--- a/samples/trigger-customizations/200-rabbitmq.yaml
+++ b/samples/trigger-customizations/200-rabbitmq.yaml
@@ -1,0 +1,8 @@
+# RabbitMQ cluster used by the Broker
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: rabbitmq
+  namespace: trigger-demo
+spec:
+  replicas: 1

--- a/samples/trigger-customizations/300-broker.yaml
+++ b/samples/trigger-customizations/300-broker.yaml
@@ -1,0 +1,12 @@
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: default
+  namespace: trigger-demo
+  annotations:
+    eventing.knative.dev/broker.class: RabbitMQBroker
+spec:
+  config:
+    apiVersion: rabbitmq.com/v1beta1
+    kind: RabbitmqCluster
+    name: rabbitmq

--- a/samples/trigger-customizations/400-trigger.yaml
+++ b/samples/trigger-customizations/400-trigger.yaml
@@ -1,0 +1,32 @@
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: fifo-trigger
+  namespace: trigger-demo
+spec:
+  broker: default
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: fifo-event-display
+      namespace: trigger-demo
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: high-throughput-trigger
+  namespace: trigger-demo
+  annotations:
+    # Value must be between 1 and 1000
+    # A value of 1 RabbitMQ Trigger behaves as a FIFO queue
+    # Values above 1 break message ordering guarantees but can be seen as more performance oriented.
+    rabbitmq.eventing.knative.dev/prefetchCount: "10"
+spec:
+  broker: default
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: high-throughput-event-display
+      namespace: trigger-demo

--- a/samples/trigger-customizations/500-sink.yaml
+++ b/samples/trigger-customizations/500-sink.yaml
@@ -1,0 +1,25 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: fifo-event-display
+  namespace: trigger-demo
+spec:
+  template:
+    spec:
+      containers:
+      - image: ko://knative.dev/eventing-rabbitmq/samples/trigger-customizations/event-display
+        args:
+          - --delay=20
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: high-throughput-event-display
+  namespace: trigger-demo
+spec:
+  template:
+    spec:
+      containers:
+        - image: ko://knative.dev/eventing-rabbitmq/samples/trigger-customizations/event-display
+          args:
+            - --delay=20

--- a/samples/trigger-customizations/500-sink.yaml
+++ b/samples/trigger-customizations/500-sink.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: trigger-demo
 spec:
   template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
       - image: ko://knative.dev/eventing-rabbitmq/samples/trigger-customizations/event-display
@@ -18,6 +21,9 @@ metadata:
   namespace: trigger-demo
 spec:
   template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
         - image: ko://knative.dev/eventing-rabbitmq/samples/trigger-customizations/event-display

--- a/samples/trigger-customizations/600-event-sender.yaml
+++ b/samples/trigger-customizations/600-event-sender.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: event-sender
+  namespace: trigger-demo
+spec:
+  restartPolicy: Never
+  containers:
+    - name: event-sender
+      image: ko://knative.dev/eventing-rabbitmq/samples/trigger-customizations/event-sender
+      args:
+        - --sink=http://default-broker-ingress.trigger-demo.svc.cluster.local
+        - --event={"specversion":"1.0","type":"SenderEvent","source":"Sender","datacontenttype":"application/json","data":{}}
+        - --num-messages=10

--- a/samples/trigger-customizations/README.md
+++ b/samples/trigger-customizations/README.md
@@ -7,19 +7,6 @@
 - Set `KO_DOCKER_REPO` to an accessible container registry
 
 ## Overview
-
-This doc and demos highlight the various customizations that can be done on a Trigger along with their usecases and implications.
-
-### Trigger Pre-Fetch Count
-Trigger has a configurable annotation `rabbitmq.eventing.knative.dev/prefetchCount`. The following are effects of setting this parameter to `n`:
-
-- Prefetch count is set on the RabbitMQ channel and queue created for this trigger. The channel will receive a maximum of `n` number of messages at once.
-- The trigger will create `n` workers to consume messages off the queue and dispatch to the sink.
-
-If this value is unset, it will default to `1`. This means the trigger will only handle one event at a time. This will preserve the order of the messages in a queue but
-will make the trigger a bottleneck. A slow processing sink will result in low overall throughput. Setting a value higher than 1 will result in `n` events being handled at
-a time by the trigger but ordering won't be guaranteed as events are sent to the sink.
-
 The following demo highlights the benefits and tradeoffs of setting the prefetch count to > 1 and leaving it as 1.
 
 #### Configuration

--- a/samples/trigger-customizations/README.md
+++ b/samples/trigger-customizations/README.md
@@ -1,0 +1,267 @@
+# Trigger example with customizations
+
+## Prerequisites and installation
+
+- Follow instructions listed [here](../../broker/operator-based.md#prerequisites) 
+- Install [KO](https://github.com/google/ko). It is used to create the images that will be used in this demo
+- Set `KO_DOCKER_REPO` to an accessible container registry
+
+## Overview
+
+This doc and demos highlight the various customizations that can be done on a Trigger along with their usecases and implications.
+
+### Trigger Pre-Fetch Count
+Trigger has a configurable annotation `rabbitmq.eventing.knative.dev/prefetchCount`. The following are effects of setting this parameter to `n`:
+
+- Prefetch count is set on the RabbitMQ channel and queue created for this trigger. The channel will receive a maximum of `n` number of messages at once.
+- The trigger will create `n` workers to consume messages off the queue and dispatch to the sink.  
+
+If this value is unset, it will default to `1`. This means the trigger will only handle one event at a time. This will preserve the order of the messages in a queue but 
+will make the trigger a bottleneck. A slow processing sink will result in low overall throughput. Setting a value higher than 1 will result in `n` events being handled at
+a time by the trigger but ordering won't be guaranteed as events are sent to the sink.
+
+The following demo highlights the benefits and tradeoffs of setting the prefetch count to > 1 and leaving it as 1. 
+
+#### Configuration
+- Create a RabbitMQ cluster and broker
+- Create a source that will send 10 events all at once to a broker
+- Create a first-in-first-out (FIFO) trigger with prefetch count unset (defaults to 1)
+- Create a high-throughput trigger with prefetch count set to 10
+- Create a slow sink for each trigger
+- Observe the results through the logs of the sinks
+
+#### Components
+New components introduced in this demo:
+
+- [event-sender](https://github.com/knative-sandbox/eventing-rabbitmq/tree/main/samples/trigger-customizations/event-sender) 
+  Is used to send `n` messages to a broker.
+
+- [event-display](https://github.com/knative-sandbox/eventing-rabbitmq/tree/main/samples/trigger-customizations/event-display)
+  Is used as a "slow" sink. It will wait for `delay` number of seconds for each event it consumes. 
+
+#### Steps
+Execute the following steps/commands from the root of this repo.
+
+#### Create a namespace
+Create a new namespace for the demo. This will make cleanup easier.
+
+```sh
+kubectl apply -f samples/trigger-customizations/100-namespace.yaml
+```
+or
+```sh
+kubectl create ns trigger-demo
+```
+
+####Create a RabbitMQ Cluster
+
+```sh
+kubectl apply -f samples/trigger-customizations/200-rabbitmq.yaml
+```
+or
+```
+kubectl apply -f - << EOF
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: rabbitmq
+  namespace: trigger-demo
+spec:
+  replicas: 1
+EOF
+```
+
+#### Create a Broker
+```sh
+kubectl apply -f samples/trigger-customizations/300-broker.yaml
+```
+or
+```sh
+kubectl apply -f - << EOF
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: default
+  namespace: trigger-demo
+  annotations:
+    eventing.knative.dev/broker.class: RabbitMQBroker
+spec:
+  config:
+    apiVersion: rabbitmq.com/v1beta1
+    kind: RabbitmqCluster
+    name: rabbitmq
+EOF
+```
+
+#### Create the 2 Triggers
+
+```sh
+kubectl apply -f samples/trigger-customizations/400-trigger.yaml
+```
+or
+```sh
+kubectl apply -f - << EOF
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: fifo-trigger
+  namespace: trigger-demo
+spec:
+  broker: default
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: fifo-event-display
+      namespace: trigger-demo
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: high-throughput-trigger
+  namespace: trigger-demo
+  annotations:
+    # Value must be between 1 and 1000
+    # A value of 1 RabbitMQ Trigger behaves as a FIFO queue
+    # Values above 1 break message ordering guarantees but can be seen as more performance oriented.
+    rabbitmq.eventing.knative.dev/prefetchCount: "10"
+spec:
+  broker: default
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: high-throughput-event-display
+      namespace: trigger-demo
+EOF
+```
+
+#### Create the 2 Sinks
+NOTE: ko is used here to create the custom images. Ensure `KO_DOCKER_REPO` is set to an accessible repository for the images.
+```sh
+ko apply -f samples/trigger-customizations/500-sink.yaml
+```
+or
+```sh
+ko apply -f - << EOF
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: fifo-event-display
+  namespace: trigger-demo
+spec:
+  template:
+    spec:
+      containers:
+      - image: ko://knative.dev/eventing-rabbitmq/samples/trigger-customizations/event-display
+        args:
+          - --delay=20
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: high-throughput-event-display
+  namespace: trigger-demo
+spec:
+  template:
+    spec:
+      containers:
+        - image: ko://knative.dev/eventing-rabbitmq/samples/trigger-customizations/event-display
+          args:
+            - --delay=20
+
+```
+
+#### Wait for resources to become ready
+Before sending messages, wait for all relevant resources to become Ready
+```sh
+kubectl get broker -n trigger-demo
+NAME      URL                                                            AGE   READY   REASON
+default   http://default-broker-ingress.trigger-demo.svc.cluster.local   95s   True
+
+kubectl get trigger -n trigger-demo
+NAME                      BROKER    SUBSCRIBER_URI                                                        AGE    READY   REASON
+fifo-trigger              default   http://fifo-event-display.trigger-demo.svc.cluster.local              5m1s   True
+high-throughput-trigger   default   http://high-throughput-event-display.trigger-demo.svc.cluster.local   5m1s   True
+
+kubectl get services.serving.knative.dev -n trigger-demo
+NAME                            URL                                                             LATESTCREATED                         LATESTREADY                           READY   REASON
+fifo-event-display              http://fifo-event-display.trigger-demo.example.com              fifo-event-display-00001              fifo-event-display-00001              True
+high-throughput-event-display   http://high-throughput-event-display.trigger-demo.example.com   high-throughput-event-display-00001   high-throughput-event-display-00001   True
+```
+
+#### Create the Source
+Create the source to start sending messages. 
+<br/>
+NOTE: ensure the `--sink` is set to the broker's ingress URL.
+
+```sh
+ko apply -f samples/trigger-customizations/600-event-sender.yaml
+```
+or
+```sh
+ko apply -f - << EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: event-sender
+  namespace: trigger-demo
+spec:
+  restartPolicy: Never
+  containers:
+    - name: event-sender
+      image: ko://knative.dev/eventing-rabbitmq/samples/trigger-customizations/event-sender
+      args:
+        - --sink=http://default-broker-ingress.trigger-demo.svc.cluster.local
+        - --event={"specversion":"1.0","type":"SenderEvent","source":"Sender","datacontenttype":"application/json","data":{}}
+        - --num-messages=10
+EOF
+```
+
+### Start watching the results
+Once the event-display pods are up and running, watch for logs in the FIFO event display. Once the sender has been created (and after the delay), you should see
+events being consumed in order. But this sink will take longer to process all of the incoming events.
+
+```sh
+kubectl -n trigger-demo -l='serving.knative.dev/service=fifo-event-display' logs -c user-container -f
+processed event with ID: 1
+processed event with ID: 2
+processed event with ID: 3
+processed event with ID: 4
+processed event with ID: 5
+processed event with ID: 6
+processed event with ID: 7
+processed event with ID: 8
+processed event with ID: 9
+processed event with ID: 10
+```
+
+And in a different shell, watch for logs from the high-throughput sink. Once the sender is created (and after the delay), you should
+see all the events getting consumed fairly quickly. But they will likely be out of order.
+
+```sh
+kubectl -n trigger-demo -l='serving.knative.dev/service=high-throughput-event-display' logs -c user-container -f
+processed event with ID: 1
+processed event with ID: 9
+processed event with ID: 6
+processed event with ID: 2
+processed event with ID: 10
+processed event with ID: 7
+processed event with ID: 8
+processed event with ID: 3
+processed event with ID: 4
+processed event with ID: 5
+```
+
+
+
+#### Cleanup
+Delete the trigger-demo namespace to easily remove all the created resources 
+
+```sh
+kubectl delete -f samples/trigger-customizations/100-namespace.yaml
+```
+or
+```sh
+kubectl delete ns trigger-demo
+```

--- a/samples/trigger-customizations/README.md
+++ b/samples/trigger-customizations/README.md
@@ -33,10 +33,10 @@ The following demo highlights the benefits and tradeoffs of setting the prefetch
 #### Components
 New components introduced in this demo:
 
-- [event-sender](https://github.com/knative-sandbox/eventing-rabbitmq/tree/main/samples/trigger-customizations/event-sender)
+- [event-sender](./event-sender)
 Is used to send `n` messages to a broker.
 
-- [event-display](https://github.com/knative-sandbox/eventing-rabbitmq/tree/main/samples/trigger-customizations/event-display)
+- [event-display](./event-display)
 Is used as a "slow" sink. It will wait for `delay` number of seconds for each event it consumes.
 
 #### Steps
@@ -53,7 +53,7 @@ or
 kubectl create ns trigger-demo
 ```
 
-####Create a RabbitMQ Cluster
+#### Create a RabbitMQ Cluster
 
 ```sh
 kubectl apply -f samples/trigger-customizations/200-rabbitmq.yaml
@@ -151,6 +151,9 @@ metadata:
   namespace: trigger-demo
 spec:
   template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
       - image: ko://knative.dev/eventing-rabbitmq/samples/trigger-customizations/event-display
@@ -164,12 +167,15 @@ metadata:
   namespace: trigger-demo
 spec:
   template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
         - image: ko://knative.dev/eventing-rabbitmq/samples/trigger-customizations/event-display
           args:
             - --delay=20
-
+EOF
 ```
 
 #### Wait for resources to become ready

--- a/samples/trigger-customizations/README.md
+++ b/samples/trigger-customizations/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites and installation
 
-- Follow instructions listed [here](../../broker/operator-based.md#prerequisites) 
+- Follow instructions listed [here](../../broker/operator-based.md#prerequisites)
 - Install [KO](https://github.com/google/ko). It is used to create the images that will be used in this demo
 - Set `KO_DOCKER_REPO` to an accessible container registry
 
@@ -14,13 +14,13 @@ This doc and demos highlight the various customizations that can be done on a Tr
 Trigger has a configurable annotation `rabbitmq.eventing.knative.dev/prefetchCount`. The following are effects of setting this parameter to `n`:
 
 - Prefetch count is set on the RabbitMQ channel and queue created for this trigger. The channel will receive a maximum of `n` number of messages at once.
-- The trigger will create `n` workers to consume messages off the queue and dispatch to the sink.  
+- The trigger will create `n` workers to consume messages off the queue and dispatch to the sink.
 
-If this value is unset, it will default to `1`. This means the trigger will only handle one event at a time. This will preserve the order of the messages in a queue but 
+If this value is unset, it will default to `1`. This means the trigger will only handle one event at a time. This will preserve the order of the messages in a queue but
 will make the trigger a bottleneck. A slow processing sink will result in low overall throughput. Setting a value higher than 1 will result in `n` events being handled at
 a time by the trigger but ordering won't be guaranteed as events are sent to the sink.
 
-The following demo highlights the benefits and tradeoffs of setting the prefetch count to > 1 and leaving it as 1. 
+The following demo highlights the benefits and tradeoffs of setting the prefetch count to > 1 and leaving it as 1.
 
 #### Configuration
 - Create a RabbitMQ cluster and broker
@@ -33,11 +33,11 @@ The following demo highlights the benefits and tradeoffs of setting the prefetch
 #### Components
 New components introduced in this demo:
 
-- [event-sender](https://github.com/knative-sandbox/eventing-rabbitmq/tree/main/samples/trigger-customizations/event-sender) 
-  Is used to send `n` messages to a broker.
+- [event-sender](https://github.com/knative-sandbox/eventing-rabbitmq/tree/main/samples/trigger-customizations/event-sender)
+Is used to send `n` messages to a broker.
 
 - [event-display](https://github.com/knative-sandbox/eventing-rabbitmq/tree/main/samples/trigger-customizations/event-display)
-  Is used as a "slow" sink. It will wait for `delay` number of seconds for each event it consumes. 
+Is used as a "slow" sink. It will wait for `delay` number of seconds for each event it consumes.
 
 #### Steps
 Execute the following steps/commands from the root of this repo.
@@ -191,7 +191,7 @@ high-throughput-event-display   http://high-throughput-event-display.trigger-dem
 ```
 
 #### Create the Source
-Create the source to start sending messages. 
+Create the source to start sending messages.
 <br/>
 NOTE: ensure the `--sink` is set to the broker's ingress URL.
 
@@ -253,10 +253,8 @@ processed event with ID: 4
 processed event with ID: 5
 ```
 
-
-
 #### Cleanup
-Delete the trigger-demo namespace to easily remove all the created resources 
+Delete the trigger-demo namespace to easily remove all the created resources
 
 ```sh
 kubectl delete -f samples/trigger-customizations/100-namespace.yaml

--- a/samples/trigger-customizations/event-display/main.go
+++ b/samples/trigger-customizations/event-display/main.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/cloudevents/sdk-go/observability/opencensus/v2/client"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+var (
+	delay int
+)
+
+func init() {
+	flag.IntVar(&delay, "delay", 20, "delay in seconds when processing messages")
+}
+
+// display prints the given Event's ID.
+func display(event cloudevents.Event) {
+	time.Sleep(time.Duration(delay) * time.Second)
+	fmt.Printf("processed event with ID: %s\n", event.ID())
+}
+
+func main() {
+	run(context.Background())
+}
+
+func run(ctx context.Context) {
+	c, err := client.NewClientHTTP(nil, nil)
+	if err != nil {
+		log.Fatal("Failed to create client: ", err)
+	}
+
+	if err := c.StartReceiver(ctx, display); err != nil {
+		log.Fatal("Error during receiver's runtime: ", err)
+	}
+	log.Print("starting event display\n")
+}

--- a/samples/trigger-customizations/event-sender/main.go
+++ b/samples/trigger-customizations/event-sender/main.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+)
+
+var (
+	sink       string
+	inputEvent string
+	numMsg     int
+)
+
+func init() {
+	flag.StringVar(&sink, "sink", "", "The sink url for the message destination.")
+	flag.StringVar(&inputEvent, "event", "", "Event JSON encoded")
+	flag.IntVar(&numMsg, "num-messages", 100, "The number of messages to attempt to send.")
+}
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+	ctx = cloudevents.WithEncodingBinary(ctx)
+
+	httpOpts := []cehttp.Option{
+		cloudevents.WithTarget(sink),
+	}
+
+	t, err := cloudevents.NewHTTP(httpOpts...)
+	if err != nil {
+		log.Fatalf("failed to create transport, %v", err)
+	}
+
+	c, err := cloudevents.NewClient(t)
+	if err != nil {
+		log.Fatalf("failed to create client, %v", err)
+	}
+
+	var baseEvent cloudevents.Event
+	if err := json.Unmarshal([]byte(inputEvent), &baseEvent); err != nil {
+		log.Fatalf("Unable to unmarshal the event from json: %v", err)
+	}
+
+	for i := 0; i < numMsg; i++ {
+		event := baseEvent.Clone()
+		event.SetID(fmt.Sprintf("%d", i+1))
+
+		log.Printf("I'm going to send\n%s\n", event)
+
+		if result := c.Send(ctx, event); !cloudevents.IsACK(result) {
+			log.Printf("failed to send cloudevent: %s", result.Error())
+		}
+	}
+}


### PR DESCRIPTION
# Changes
Starts a `trigger-customization` section and adds prefetch count examples

/kind documentation

Fixes #424 
