### PR TITLE
Remove requeue from dispatcher properties in favour of retries

### DIFF
--- a/cmd/dispatcher/main.go
+++ b/cmd/dispatcher/main.go
@@ -41,8 +41,6 @@ type envConfig struct {
 	RabbitURL        string `envconfig:"RABBIT_URL" required:"true"`
 	BrokerIngressURL string `envconfig:"BROKER_INGRESS_URL" required:"true"`
 	SubscriberURL    string `envconfig:"SUBSCRIBER" required:"true"`
-	// Should failed deliveries be requeued in the RabbitMQ?
-	Requeue bool `envconfig:"REQUEUE" default:"false" required:"true"`
 
 	// Number of concurrent messages in flight
 	PrefetchCount int           `envconfig:"PREFETCH_COUNT" default:"1" required:"false"`
@@ -115,7 +113,6 @@ func main() {
 	d := &dispatcher.Dispatcher{
 		BrokerIngressURL: env.BrokerIngressURL,
 		SubscriberURL:    env.SubscriberURL,
-		Requeue:          env.Requeue,
 		MaxRetries:       env.Retry,
 		BackoffDelay:     backoffDelay,
 		BackoffPolicy:    backoffPolicy,

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -46,10 +46,10 @@ const (
 type Dispatcher struct {
 	BrokerIngressURL string
 	SubscriberURL    string
-	MaxRetries    int
-	BackoffDelay  time.Duration
-	BackoffPolicy eventingduckv1.BackoffPolicyType
-	WorkerCount   int
+	MaxRetries       int
+	BackoffDelay     time.Duration
+	BackoffPolicy    eventingduckv1.BackoffPolicyType
+	WorkerCount      int
 }
 
 // ConsumeFromQueue consumes messages from the given message channel and queue.

--- a/pkg/reconciler/trigger/resources/dispatcher.go
+++ b/pkg/reconciler/trigger/resources/dispatcher.go
@@ -95,11 +95,6 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 		dispatcher.Env = append(dispatcher.Env, args.Configs.ToEnvVars()...)
 	}
 	if args.Delivery != nil {
-		dispatcher.Env = append(dispatcher.Env,
-			corev1.EnvVar{
-				Name:  "REQUEUE",
-				Value: "false",
-			})
 		if args.Delivery.Retry != nil {
 			dispatcher.Env = append(dispatcher.Env,
 				corev1.EnvVar{
@@ -121,13 +116,6 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 					Value: string(*args.Delivery.BackoffPolicy),
 				})
 		}
-	} else {
-		dispatcher.Env = append(dispatcher.Env,
-			// TODO: We should remove REQUEUE, it is not used.
-			corev1.EnvVar{
-				Name:  "REQUEUE",
-				Value: "false",
-			})
 	}
 	if prefetch, ok := args.Trigger.ObjectMeta.Annotations[prefetchAnnotation]; ok {
 		dispatcher.Env = append(dispatcher.Env,

--- a/pkg/reconciler/trigger/resources/dispatcher_test.go
+++ b/pkg/reconciler/trigger/resources/dispatcher_test.go
@@ -148,9 +148,6 @@ func deployment(opts ...func(*appsv1.Deployment)) *appsv1.Deployment {
 						}, {
 							Name:  "BROKER_INGRESS_URL",
 							Value: brokerIngressURL,
-						}, {
-							Name:  "REQUEUE",
-							Value: "false",
 						}},
 					}},
 				},


### PR DESCRIPTION
# Changes
- Removes Requeue as an env option on dispatcher. 
- In it's current state, it was always set to false and wasn't configurable by the user.
- Tests updated to use retries to achieve the expected events at the broker and subscriber. 

One test case was more heavily modified: 
Used to be: 
- dispatcher with requeue set to true
- send one event
- subscriber responds with success + response event
- send response event back to broker
- broker responds with failure
- requeue
- subscriber responds with success + response event
- broker responds with success

The same end state is achieved with retries but the retries are more granular. Can retry subscriber and broker individually instead of re-queueing and sending duplicates to the subscriber. As a result, subscriber only sees 1 event and the broker will see the 2 attempts.

/kind cleanup


Fixes #591  

