### PR TITLE
Recreating RabbitMQ's Connections and Channels in the Source Receive Adapter

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -305,7 +305,7 @@ func (a *Adapter) PollForMessages(queue *wabbit.Queue, stopCh <-chan struct{}) e
 			return nil
 		case msg, ok := <-msgs:
 			if !ok {
-				logger.Warn("not ok message comming from the queue", zap.Any("msg", msg))
+				logger.Warn("not ok message coming from the queue", zap.Any("msg", msg))
 				err := a.setupRabbitMQ(nil)
 				if err != nil {
 					logger.Error("Error reconnecting to RabbitMQ", zap.Error(err))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Recreate RabbitMQ
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Recreate RabbitMQ's Connections and Channels in the Source Receive Adapter on unexpected failures
- 🧹 Some cleanup in the Source Receive Adapter's code

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes Part of #647

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
 Recreate RabbitMQ's Connections and Channels in the Source Receive Adapter on unexpected failures
```

