### PR TITLE
Small refactors: remove unused context from NewExchange() and NewQueue()

### DIFF
--- a/pkg/rabbit/service.go
+++ b/pkg/rabbit/service.go
@@ -48,7 +48,7 @@ type Rabbit struct {
 func (r *Rabbit) ReconcileExchange(ctx context.Context, args *resources.ExchangeArgs) (Result, error) {
 	logging.FromContext(ctx).Infow("Reconciling exchange", zap.String("name", args.Name))
 
-	want := resources.NewExchange(ctx, args)
+	want := resources.NewExchange(args)
 	current, err := r.RabbitmqV1beta1().Exchanges(args.Namespace).Get(ctx, args.Name, metav1.GetOptions{})
 	if apierrs.IsNotFound(err) {
 		logging.FromContext(ctx).Debugw("Creating rabbitmq exchange", zap.String("exchange name", want.Name))

--- a/pkg/rabbit/service.go
+++ b/pkg/rabbit/service.go
@@ -73,7 +73,7 @@ func (r *Rabbit) ReconcileExchange(ctx context.Context, args *resources.Exchange
 func (r *Rabbit) ReconcileQueue(ctx context.Context, args *triggerresources.QueueArgs) (Result, error) {
 	logging.FromContext(ctx).Info("Reconciling queue")
 
-	want := triggerresources.NewQueue(ctx, args)
+	want := triggerresources.NewQueue(args)
 	queue, err := r.RabbitmqV1beta1().Queues(args.Namespace).Get(ctx, want.Name, metav1.GetOptions{})
 	if apierrs.IsNotFound(err) {
 		logging.FromContext(ctx).Debugw("Creating rabbitmq queue", zap.String("queue", want.Name))

--- a/pkg/reconciler/broker/resources/exchange.go
+++ b/pkg/reconciler/broker/resources/exchange.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"context"
 	"net/url"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +37,7 @@ type ExchangeArgs struct {
 	Trigger                  *eventingv1.Trigger
 }
 
-func NewExchange(ctx context.Context, args *ExchangeArgs) *rabbitv1beta1.Exchange {
+func NewExchange(args *ExchangeArgs) *rabbitv1beta1.Exchange {
 	var ownerReference metav1.OwnerReference
 
 	if args.Trigger != nil {

--- a/pkg/reconciler/broker/resources/exchange_test.go
+++ b/pkg/reconciler/broker/resources/exchange_test.go
@@ -1,7 +1,6 @@
 package resources_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -170,7 +169,7 @@ func TestNewExchange(t *testing.T) {
 		},
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resources.NewExchange(context.TODO(), tt.args)
+			got := resources.NewExchange(tt.args)
 			if !equality.Semantic.DeepDerivative(tt.want, got) {
 				t.Errorf("Unexpected Exchange resource: want:\n%+v\ngot:\n%+v\ndiff:\n%+v", tt.want, got, cmp.Diff(tt.want, got))
 			}

--- a/pkg/reconciler/broker/resources/exchange_test.go
+++ b/pkg/reconciler/broker/resources/exchange_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resources_test
 
 import (

--- a/pkg/reconciler/trigger/resources/queue.go
+++ b/pkg/reconciler/trigger/resources/queue.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 
@@ -42,8 +41,8 @@ type QueueArgs struct {
 	DLXName                  *string
 }
 
-func NewQueue(ctx context.Context, args *QueueArgs) *rabbitv1beta1.Queue {
-	q := &rabbitv1beta1.Queue{
+func NewQueue(args *QueueArgs) *rabbitv1beta1.Queue {
+	return &rabbitv1beta1.Queue{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       args.Namespace,
 			Name:            args.Name,
@@ -64,7 +63,6 @@ func NewQueue(ctx context.Context, args *QueueArgs) *rabbitv1beta1.Queue {
 			},
 		},
 	}
-	return q
 }
 
 func NewPolicy(args *QueueArgs) *rabbitv1beta1.Policy {

--- a/pkg/reconciler/trigger/resources/queue_test.go
+++ b/pkg/reconciler/trigger/resources/queue_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -102,7 +101,7 @@ func TestNewQueue(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resources.NewQueue(context.TODO(), tt.args)
+			got := resources.NewQueue(tt.args)
 			if !equality.Semantic.DeepDerivative(tt.want, got) {
 				t.Errorf("Unexpected Queue resource: want:\n%+v\ngot:\n%+v\ndiff:\n%+v", tt.want, got, cmp.Diff(tt.want, got))
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :wastebasket: Small refactors: remove unused context from NewExchange() and NewQueue()

/kind cleanup
