### PR TITLE
Increase memory request/limit to 1Gi

### DIFF
--- a/test/conformance/resources/rabbitmqcluster/rabbitmqcluster.yaml
+++ b/test/conformance/resources/rabbitmqcluster/rabbitmqcluster.yaml
@@ -8,7 +8,7 @@ spec:
   resources:
     limits:
       cpu: "2000m"
-      memory: "500Mi"
+      memory: "1Gi"
     requests:
       cpu: "100m"
-      memory: "500Mi"
+      memory: "1Gi"


### PR DESCRIPTION
- 🐛  increase memory request to 1Gi for RabbitMQ clusters created during conformance testing


/kind cleanup

The tests occasionally run into an issue where during startup, the RabbitMQ server is using too much memory (~160Mi) and that triggers the memory alarm threshold. When that alarm is triggered, producers are blocked. This causes a failure in the test where the message is stuck at the ingress pod and doesn't proceed any further. 