### PR TITLE
Rename rmqsource exchangeConfig TypeOf to Type

### DIFF
--- a/pkg/apis/sources/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_types.go
@@ -71,7 +71,7 @@ type RabbitmqSourceExchangeConfigSpec struct {
 	Name string `json:"name,omitempty"`
 	// Type of exchange e.g. direct, topic, headers, fanout
 	// +required
-	TypeOf string `json:"type,omitempty"`
+	Type string `json:"type,omitempty"`
 	// Exchange is Durable or not
 	// +optional
 	Durable bool `json:"durable,omitempty"`

--- a/pkg/apis/sources/v1alpha1/rabbitmq_validation_test.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_validation_test.go
@@ -30,7 +30,7 @@ var (
 		Brokers: "amqp://guest:guest@localhost:5672/",
 		Topic:   "logs_topic",
 		ExchangeConfig: RabbitmqSourceExchangeConfigSpec{
-			TypeOf:     "topic",
+			Type:       "topic",
 			Durable:    true,
 			AutoDelete: false,
 			Internal:   false,

--- a/pkg/reconciler/broker/resources/exchange.go
+++ b/pkg/reconciler/broker/resources/exchange.go
@@ -60,7 +60,7 @@ func NewExchange(args *ExchangeArgs) *rabbitv1beta1.Exchange {
 		ownerReference = *kmeta.NewControllerRef(args.Source)
 		durable = args.Source.Spec.ExchangeConfig.Durable
 		autoDelete = args.Source.Spec.ExchangeConfig.AutoDelete
-		exchangeType = args.Source.Spec.ExchangeConfig.TypeOf
+		exchangeType = args.Source.Spec.ExchangeConfig.Type
 		exchangeName = args.Source.Spec.ExchangeConfig.Name
 		vhost = args.Source.Spec.Vhost
 	}

--- a/pkg/reconciler/broker/resources/exchange_test.go
+++ b/pkg/reconciler/broker/resources/exchange_test.go
@@ -160,7 +160,7 @@ func TestNewExchange(t *testing.T) {
 				Spec: v1alpha1.RabbitmqSourceSpec{
 					ExchangeConfig: v1alpha1.RabbitmqSourceExchangeConfigSpec{
 						Name:       "some-exchange",
-						TypeOf:     "direct",
+						Type:       "direct",
 						Durable:    false,
 						AutoDelete: false,
 						NoWait:     false,

--- a/pkg/reconciler/source/resources/receive_adapter.go
+++ b/pkg/reconciler/source/resources/receive_adapter.go
@@ -79,7 +79,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 		},
 		{
 			Name:  "RABBITMQ_EXCHANGE_CONFIG_TYPE",
-			Value: args.Source.Spec.ExchangeConfig.TypeOf,
+			Value: args.Source.Spec.ExchangeConfig.Type,
 		},
 		{
 			Name:  "RABBITMQ_EXCHANGE_CONFIG_DURABLE",

--- a/pkg/reconciler/source/resources/receive_adapter_test.go
+++ b/pkg/reconciler/source/resources/receive_adapter_test.go
@@ -75,7 +75,7 @@ func TestMakeReceiveAdapter(t *testing.T) {
 					Predeclared: true,
 					ExchangeConfig: v1alpha12.RabbitmqSourceExchangeConfigSpec{
 						Name:       "logs",
-						TypeOf:     "topic",
+						Type:       "topic",
 						Durable:    true,
 						AutoDelete: false,
 						Internal:   false,


### PR DESCRIPTION
# Changes

- :broom: This only renames the the struct field name, json key is 'type' already

/kind cleanup

