### PR TITLE
Move NewPolicy() NewExchange() NewBinding() NewQueue() to pkg/rabbit

### DIFF
--- a/pkg/rabbit/binding.go
+++ b/pkg/rabbit/binding.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package rabbit
 
 import (
 	"encoding/json"

--- a/pkg/rabbit/binding_test.go
+++ b/pkg/rabbit/binding_test.go
@@ -14,35 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources_test
+package rabbit_test
 
 import (
 	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"knative.dev/eventing-rabbitmq/pkg/rabbit"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"knative.dev/eventing-rabbitmq/pkg/reconciler/trigger/resources"
 	rabbitv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 )
 
-const (
-	brokerName      = "testbroker"
-	brokerUID       = "broker-test-uid"
-	rabbitmqcluster = "testrabbitmqcluster"
-)
-
 func TestNewBinding(t *testing.T) {
+	var (
+		brokerName      = "testbroker"
+		brokerUID       = types.UID("broker-test-uid")
+		rabbitmqcluster = "testrabbitmqcluster"
+		namespace       = "foobar"
+	)
+
 	for _, tt := range []struct {
 		name    string
-		args    *resources.BindingArgs
+		args    *rabbit.BindingArgs
 		want    *rabbitv1beta1.Binding
 		wantErr string
 	}{
 		{
 			name: "Creates a binding",
-			args: &resources.BindingArgs{
+			args: &rabbit.BindingArgs{
 				Namespace: namespace,
 				Name:      "name",
 				RabbitmqClusterReference: &rabbitv1beta1.RabbitmqClusterReference{
@@ -87,7 +91,7 @@ func TestNewBinding(t *testing.T) {
 		},
 		{
 			name: "Creates a binding in RabbitMQ cluster namespace",
-			args: &resources.BindingArgs{
+			args: &rabbit.BindingArgs{
 				Namespace: namespace,
 				Name:      "name",
 				RabbitmqClusterReference: &rabbitv1beta1.RabbitmqClusterReference{
@@ -134,7 +138,7 @@ func TestNewBinding(t *testing.T) {
 		},
 		{
 			name: "appends to filters if given",
-			args: &resources.BindingArgs{
+			args: &rabbit.BindingArgs{
 				Vhost: "/",
 				RabbitmqClusterReference: &rabbitv1beta1.RabbitmqClusterReference{
 					Name:      rabbitmqcluster,
@@ -153,7 +157,7 @@ func TestNewBinding(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resources.NewBinding(tt.args)
+			got, err := rabbit.NewBinding(tt.args)
 			if err != nil && tt.wantErr != "" {
 				t.Errorf("Got unexpected error return from NewBinding, wanted %v got %v", tt.wantErr, err)
 			} else if err == nil && tt.wantErr != "" {

--- a/pkg/rabbit/exchange.go
+++ b/pkg/rabbit/exchange.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package rabbit
 
 import (
 	"net/url"

--- a/pkg/rabbit/exchange_test.go
+++ b/pkg/rabbit/exchange_test.go
@@ -14,10 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources_test
+package rabbit_test
 
 import (
 	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"knative.dev/eventing-rabbitmq/pkg/rabbit"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
@@ -26,32 +30,31 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing-rabbitmq/pkg/reconciler/broker/resources"
 	rabbitv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-const (
-	brokerName       = "testbroker"
-	brokerUID        = "broker-test-uid"
-	triggerName      = "testtrigger"
-	triggerUID       = "trigger-test-uid"
-	namespace        = "foobar"
-	rabbitmqcluster  = "testrabbitmqcluster"
-	connectionSecret = "secret-name"
-	sourceName       = "a-source"
-	sourceUID        = "source-test-uid"
-)
-
 func TestNewExchange(t *testing.T) {
+	var (
+		brokerName       = "testbroker"
+		brokerUID        = types.UID("broker-test-uid")
+		triggerName      = "testtrigger"
+		triggerUID       = types.UID("trigger-test-uid")
+		sourceName       = "a-source"
+		sourceUID        = types.UID("source-test-uid")
+		namespace        = "foobar"
+		rabbitmqcluster  = "testrabbitmqcluster"
+		connectionSecret = "secret-name"
+	)
+
 	for _, tt := range []struct {
 		name string
-		args *resources.ExchangeArgs
+		args *rabbit.ExchangeArgs
 		want *rabbitv1beta1.Exchange
 	}{{
 		name: "broker exchange",
-		args: &resources.ExchangeArgs{
+		args: &rabbit.ExchangeArgs{
 			Name:      brokerName,
 			Namespace: namespace,
 			RabbitmqClusterReference: &rabbitv1beta1.RabbitmqClusterReference{
@@ -96,7 +99,7 @@ func TestNewExchange(t *testing.T) {
 		},
 	}, {
 		name: "broker exchange in RabbitMQ cluster namespace",
-		args: &resources.ExchangeArgs{
+		args: &rabbit.ExchangeArgs{
 			Name:      brokerName,
 			Namespace: namespace,
 			RabbitmqClusterReference: &rabbitv1beta1.RabbitmqClusterReference{
@@ -143,7 +146,7 @@ func TestNewExchange(t *testing.T) {
 		},
 	}, {
 		name: "source exchange",
-		args: &resources.ExchangeArgs{
+		args: &rabbit.ExchangeArgs{
 			Name:      sourceName,
 			Namespace: namespace,
 			RabbitmqClusterReference: &rabbitv1beta1.RabbitmqClusterReference{
@@ -202,7 +205,7 @@ func TestNewExchange(t *testing.T) {
 		},
 	}, {
 		name: "trigger exchange",
-		args: &resources.ExchangeArgs{
+		args: &rabbit.ExchangeArgs{
 			Name:      brokerName,
 			Namespace: namespace,
 			RabbitmqClusterReference: &rabbitv1beta1.RabbitmqClusterReference{
@@ -257,7 +260,7 @@ func TestNewExchange(t *testing.T) {
 		},
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resources.NewExchange(tt.args)
+			got := rabbit.NewExchange(tt.args)
 			if !equality.Semantic.DeepDerivative(tt.want, got) {
 				t.Errorf("Unexpected Exchange resource: want:\n%+v\ngot:\n%+v\ndiff:\n%+v", tt.want, got, cmp.Diff(tt.want, got))
 			}
@@ -266,6 +269,12 @@ func TestNewExchange(t *testing.T) {
 }
 
 func TestExchangeLabels(t *testing.T) {
+	var (
+		brokerName  = "testbroker"
+		triggerName = "testtrigger"
+		sourceName  = "a-source"
+	)
+
 	for _, tt := range []struct {
 		name string
 		b    *eventingv1.Broker
@@ -310,7 +319,7 @@ func TestExchangeLabels(t *testing.T) {
 		},
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resources.ExchangeLabels(tt.b, tt.t, tt.s)
+			got := rabbit.ExchangeLabels(tt.b, tt.t, tt.s)
 			if !equality.Semantic.DeepDerivative(tt.want, got) {
 				t.Errorf("Unexpected maps of Label: want:\n%+v\ngot:\n%+v\ndiff:\n%+v", tt.want, got, cmp.Diff(tt.want, got))
 			}

--- a/pkg/rabbit/queue.go
+++ b/pkg/rabbit/queue.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package rabbit
 
 import (
 	"fmt"

--- a/pkg/rabbit/service.go
+++ b/pkg/rabbit/service.go
@@ -25,8 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing-rabbitmq/pkg/reconciler/broker/resources"
-	triggerresources "knative.dev/eventing-rabbitmq/pkg/reconciler/trigger/resources"
 	"knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 	rabbitclientset "knative.dev/eventing-rabbitmq/third_party/pkg/client/clientset/versioned"
 	rabbitmqclient "knative.dev/eventing-rabbitmq/third_party/pkg/client/injection/client"
@@ -45,10 +43,10 @@ type Rabbit struct {
 	rabbitclientset.Interface
 }
 
-func (r *Rabbit) ReconcileExchange(ctx context.Context, args *resources.ExchangeArgs) (Result, error) {
+func (r *Rabbit) ReconcileExchange(ctx context.Context, args *ExchangeArgs) (Result, error) {
 	logging.FromContext(ctx).Infow("Reconciling exchange", zap.String("name", args.Name))
 
-	want := resources.NewExchange(args)
+	want := NewExchange(args)
 	current, err := r.RabbitmqV1beta1().Exchanges(args.Namespace).Get(ctx, args.Name, metav1.GetOptions{})
 	if apierrs.IsNotFound(err) {
 		logging.FromContext(ctx).Debugw("Creating rabbitmq exchange", zap.String("exchange name", want.Name))
@@ -70,10 +68,10 @@ func (r *Rabbit) ReconcileExchange(ctx context.Context, args *resources.Exchange
 	}, nil
 }
 
-func (r *Rabbit) ReconcileQueue(ctx context.Context, args *triggerresources.QueueArgs) (Result, error) {
+func (r *Rabbit) ReconcileQueue(ctx context.Context, args *QueueArgs) (Result, error) {
 	logging.FromContext(ctx).Info("Reconciling queue")
 
-	want := triggerresources.NewQueue(args)
+	want := NewQueue(args)
 	queue, err := r.RabbitmqV1beta1().Queues(args.Namespace).Get(ctx, want.Name, metav1.GetOptions{})
 	if apierrs.IsNotFound(err) {
 		logging.FromContext(ctx).Debugw("Creating rabbitmq queue", zap.String("queue", want.Name))
@@ -93,7 +91,7 @@ func (r *Rabbit) ReconcileQueue(ctx context.Context, args *triggerresources.Queu
 
 	policyReady := true
 	if args.DLXName != nil {
-		want := triggerresources.NewPolicy(args)
+		want := NewPolicy(args)
 		policy, err := r.RabbitmqV1beta1().Policies(args.Namespace).Get(ctx, queue.Name, metav1.GetOptions{})
 		if apierrs.IsNotFound(err) {
 			logging.FromContext(ctx).Debugw("Creating rabbitmq policy", zap.String("name", queue.Name))
@@ -117,10 +115,10 @@ func (r *Rabbit) ReconcileQueue(ctx context.Context, args *triggerresources.Queu
 	}, nil
 }
 
-func (r *Rabbit) ReconcileBinding(ctx context.Context, args *triggerresources.BindingArgs) (Result, error) {
+func (r *Rabbit) ReconcileBinding(ctx context.Context, args *BindingArgs) (Result, error) {
 	logging.FromContext(ctx).Info("Reconciling binding")
 
-	want, err := triggerresources.NewBinding(args)
+	want, err := NewBinding(args)
 	if err != nil {
 		return Result{}, fmt.Errorf("failed to create the binding spec: %w", err)
 	}

--- a/pkg/rabbit/types.go
+++ b/pkg/rabbit/types.go
@@ -18,9 +18,6 @@ package rabbit
 
 import (
 	"context"
-
-	"knative.dev/eventing-rabbitmq/pkg/reconciler/broker/resources"
-	triggerresources "knative.dev/eventing-rabbitmq/pkg/reconciler/trigger/resources"
 )
 
 type Result struct {
@@ -29,7 +26,7 @@ type Result struct {
 }
 
 type Service interface {
-	ReconcileExchange(context.Context, *resources.ExchangeArgs) (Result, error)
-	ReconcileQueue(context.Context, *triggerresources.QueueArgs) (Result, error)
-	ReconcileBinding(context.Context, *triggerresources.BindingArgs) (Result, error)
+	ReconcileExchange(context.Context, *ExchangeArgs) (Result, error)
+	ReconcileQueue(context.Context, *QueueArgs) (Result, error)
+	ReconcileBinding(context.Context, *BindingArgs) (Result, error)
 }

--- a/pkg/rabbitmqnaming/naming_test.go
+++ b/pkg/rabbitmqnaming/naming_test.go
@@ -19,6 +19,8 @@ package naming
 import (
 	"testing"
 
+	"knative.dev/eventing-rabbitmq/pkg/apis/sources/v1alpha1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
@@ -29,6 +31,8 @@ const (
 	triggerName = "testtrigger"
 	triggerUID  = "triggeruid"
 	namespace   = "foobar"
+	sourceName  = "a-source"
+	sourceUID   = "asourceUID"
 )
 
 func TestExchangeName(t *testing.T) {
@@ -109,5 +113,19 @@ func TestCreateTriggerDeadLetterQueueName(t *testing.T) {
 	})
 	if want != got {
 		t.Errorf("Unexpected name for foobar/trigger Trigger DLQ: want:\n%q\ngot:\n%q", want, got)
+	}
+}
+
+func TestCreateSourceRabbitName(t *testing.T) {
+	want := "s.foobar.a-source.asourceUID"
+	got := CreateSourceRabbitName(&v1alpha1.RabbitmqSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      sourceName,
+			UID:       sourceUID,
+		},
+	})
+	if want != got {
+		t.Errorf("Unexpected name for source: want:\n%q\ngot:\n%q", want, got)
 	}
 }

--- a/pkg/reconciler/broker/broker_config.go
+++ b/pkg/reconciler/broker/broker_config.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"net/url"
 
+	"knative.dev/eventing-rabbitmq/pkg/rabbit"
+
 	rabbitv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -41,12 +43,12 @@ import (
 
 // This file contains the logic dealing with how to handle Broker.Spec.Config.
 
-func (r *Reconciler) getExchangeArgs(ctx context.Context, b *eventingv1.Broker) (*resources.ExchangeArgs, error) {
+func (r *Reconciler) getExchangeArgs(ctx context.Context, b *eventingv1.Broker) (*rabbit.ExchangeArgs, error) {
 	rabbitmqURL, err := r.rabbitmqURL(ctx, b)
 	if err != nil {
 		return nil, err
 	}
-	return &resources.ExchangeArgs{
+	return &rabbit.ExchangeArgs{
 		Namespace: b.Namespace,
 		Broker:    b,
 		RabbitmqClusterReference: &rabbitv1beta1.RabbitmqClusterReference{

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -1252,7 +1252,7 @@ func createExchange(dlx bool) *rabbitv1beta1.Exchange {
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(broker),
 			},
-			Labels: resources.ExchangeLabels(broker, nil, nil),
+			Labels: rabbit.ExchangeLabels(broker, nil, nil),
 		},
 		Spec: rabbitv1beta1.ExchangeSpec{
 			Name:       exchangeName,
@@ -1304,7 +1304,7 @@ func createQueue(dlx bool) *rabbitv1beta1.Queue {
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(broker),
 			},
-			Labels: resources.ExchangeLabels(broker, nil, nil),
+			Labels: rabbit.ExchangeLabels(broker, nil, nil),
 		},
 		Spec: rabbitv1beta1.QueueSpec{
 			Name:       queueName,
@@ -1353,7 +1353,7 @@ func createBinding(dlx bool) *rabbitv1beta1.Binding {
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(broker),
 			},
-			Labels: resources.ExchangeLabels(broker, nil, nil),
+			Labels: rabbit.ExchangeLabels(broker, nil, nil),
 		},
 		Spec: rabbitv1beta1.BindingSpec{
 			Vhost:           "/",

--- a/pkg/reconciler/broker/resources/secret.go
+++ b/pkg/reconciler/broker/resources/secret.go
@@ -19,6 +19,8 @@ package resources
 import (
 	"fmt"
 
+	"knative.dev/eventing-rabbitmq/pkg/rabbit"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/pkg/apis/eventing"
@@ -30,7 +32,7 @@ const (
 )
 
 // MakeSecret creates the secret for Broker deployments for Rabbit Broker.
-func MakeSecret(args *ExchangeArgs) *corev1.Secret {
+func MakeSecret(args *rabbit.ExchangeArgs) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: args.Broker.Namespace,

--- a/pkg/reconciler/broker/resources/secret_test.go
+++ b/pkg/reconciler/broker/resources/secret_test.go
@@ -19,6 +19,8 @@ package resources
 import (
 	"testing"
 
+	"knative.dev/eventing-rabbitmq/pkg/rabbit"
+
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +40,7 @@ func TestMakeSecret(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to parse the test URL: %s", err)
 	}
-	args := &ExchangeArgs{
+	args := &rabbit.ExchangeArgs{
 		Broker:      &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: ns}},
 		RabbitMQURL: url.URL(),
 	}

--- a/pkg/reconciler/source/rabbitmqsource.go
+++ b/pkg/reconciler/source/rabbitmqsource.go
@@ -22,8 +22,6 @@ import (
 
 	"knative.dev/eventing-rabbitmq/pkg/rabbit"
 	naming "knative.dev/eventing-rabbitmq/pkg/rabbitmqnaming"
-	brokerresources "knative.dev/eventing-rabbitmq/pkg/reconciler/broker/resources"
-	triggerresources "knative.dev/eventing-rabbitmq/pkg/reconciler/trigger/resources"
 	"knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 	rabbitlisters "knative.dev/eventing-rabbitmq/third_party/pkg/client/listers/rabbitmq.com/v1beta1"
 	"knative.dev/eventing/pkg/utils"
@@ -143,7 +141,7 @@ func (r *Reconciler) reconcileRabbitObjects(ctx context.Context, source *v1alpha
 		return nil
 	}
 
-	_, err := r.rabbit.ReconcileExchange(ctx, &brokerresources.ExchangeArgs{
+	_, err := r.rabbit.ReconcileExchange(ctx, &rabbit.ExchangeArgs{
 		Name:      naming.CreateSourceRabbitName(source),
 		Namespace: source.Namespace,
 		RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{
@@ -156,7 +154,7 @@ func (r *Reconciler) reconcileRabbitObjects(ctx context.Context, source *v1alpha
 		return err
 	}
 
-	_, err = r.rabbit.ReconcileQueue(ctx, &triggerresources.QueueArgs{
+	_, err = r.rabbit.ReconcileQueue(ctx, &rabbit.QueueArgs{
 		Name:      naming.CreateSourceRabbitName(source),
 		Namespace: source.Namespace,
 		RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{
@@ -170,7 +168,7 @@ func (r *Reconciler) reconcileRabbitObjects(ctx context.Context, source *v1alpha
 		return err
 	}
 
-	_, err = r.rabbit.ReconcileBinding(ctx, &triggerresources.BindingArgs{
+	_, err = r.rabbit.ReconcileBinding(ctx, &rabbit.BindingArgs{
 		Name:      naming.CreateSourceRabbitName(source),
 		Namespace: source.Namespace,
 		RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -1109,7 +1109,7 @@ func createPolicy(broker bool) *rabbitv1beta1.Policy {
 	} else {
 		dlxName = naming.TriggerDLXExchangeName(t)
 	}
-	return resources.NewPolicy(&resources.QueueArgs{
+	return rabbit.NewPolicy(&rabbit.QueueArgs{
 		Name:      queueName,
 		Namespace: testNS,
 		Owner:     *kmeta.NewControllerRef(t),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :broom: backfill test for CreateSourceRabbitName()
- 🧹 Move NewPolicy() NewExchange() NewBinding() NewQueue() to `pkg/rabbit`. These function were only used in `/pkg/rabbit` and it's rather messy for them to live in separate places in`pkg/reconciler/trigger` and `pkg/reconciler/broker`



/kind cleanup


