### PR TITLE
Name queue&exchange name required for rabbitmqsource

### DIFF
--- a/config/source/300-rabbitmqsource.yaml
+++ b/config/source/300-rabbitmqsource.yaml
@@ -61,7 +61,8 @@ spec:
                     description: Channel Qos global property
                     type: boolean
                   parallelism:
-                    description: Sets the Channel's Prefetch count and number of Workers to consume simultaneously from it
+                    description: Sets the Channel's Prefetch count and number of Workers
+                      to consume simultaneously from it
                     maximum: 1000
                     minimum: 1
                     type: integer
@@ -87,10 +88,11 @@ spec:
                     type: boolean
                   internal:
                     description: Declare exchange as internal or not. Exchanges declared
-                      as `internal` do not accept accept publishings.
+                      as `internal` do not accept accept publishing.
                     type: boolean
                   name:
-                    description: Name of the exchange
+                    description: Name of the exchange; Required when predeclared is
+                      false.
                     type: string
                   nowait:
                     description: Exchange NoWait property. When set to true, declare
@@ -140,8 +142,7 @@ spec:
                     description: Queue is exclusive or not.
                     type: boolean
                   name:
-                    description: Name of the queue to bind to. Queue name may be empty
-                      in which case the server will generate a unique name.
+                    description: Name of the queue to bind to; required value.
                     type: string
                   nowait:
                     description: Queue NoWait property. When set to true, the queue
@@ -151,6 +152,8 @@ spec:
                     description: Routing key of the messages to be received. Multiple
                       routing keys can be specified separated by commas. e.g. key1,key2
                     type: string
+                required:
+                - name
                 type: object
               retry:
                 description: Retry is the minimum number of retries the sender should

--- a/pkg/apis/sources/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_types.go
@@ -66,7 +66,7 @@ type RabbitmqChannelConfigSpec struct {
 }
 
 type RabbitmqSourceExchangeConfigSpec struct {
-	// Name of the exchange
+	// Name of the exchange; Required when predeclared is false.
 	// +optional
 	Name string `json:"name,omitempty"`
 	// Type of exchange e.g. direct, topic, headers, fanout
@@ -79,7 +79,7 @@ type RabbitmqSourceExchangeConfigSpec struct {
 	// +optional
 	AutoDelete bool `json:"autoDelete,omitempty"`
 	// Declare exchange as internal or not.
-	// Exchanges declared as `internal` do not accept accept publishings.
+	// Exchanges declared as `internal` do not accept accept publishing.
 	// +optional
 	Internal bool `json:"internal,omitempty"`
 	// Exchange NoWait property. When set to true,
@@ -89,10 +89,9 @@ type RabbitmqSourceExchangeConfigSpec struct {
 }
 
 type RabbitmqSourceQueueConfigSpec struct {
-	// Name of the queue to bind to.
-	// Queue name may be empty in which case the server will generate a unique name.
-	// +optional
-	Name string `json:"name,omitempty"`
+	// Name of the queue to bind to; required value.
+	// +required
+	Name string `json:"name"`
 	// Routing key of the messages to be received.
 	// Multiple routing keys can be specified separated by commas. e.g. key1,key2
 	// +optional
@@ -153,7 +152,7 @@ type RabbitmqSourceSpec struct {
 	// +optional
 	ExchangeConfig RabbitmqSourceExchangeConfigSpec `json:"exchangeConfig,omitempty"`
 	// QueueConfig config for rabbitmq queues
-	// +optional
+	// +required
 	QueueConfig RabbitmqSourceQueueConfigSpec `json:"queueConfig,omitempty"`
 	// Sink is a reference to an object that will resolve to a domain name to use as the sink.
 	// +optional

--- a/pkg/apis/sources/v1alpha1/rabbitmq_validation.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_validation.go
@@ -26,6 +26,13 @@ import (
 )
 
 func (current *RabbitmqSource) Validate(ctx context.Context) *apis.FieldError {
+	if !current.Spec.Predeclared && current.Spec.ExchangeConfig.Name == "" {
+		return &apis.FieldError{
+			Message: "Name of exchange must be provided when spec.predeclared is false",
+			Paths:   []string{"spec", "exchangeConfig", "name"},
+		}
+	}
+
 	if apis.IsInUpdate(ctx) {
 		var ignoreSpecFields cmp.Option
 		original := apis.GetBaseline(ctx).(*RabbitmqSource)
@@ -51,10 +58,10 @@ func (current *RabbitmqSource) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
-	return current.Spec.ChannelConfig.validate(ctx).ViaField("ChannelConfig")
+	return current.Spec.ChannelConfig.validate().ViaField("ChannelConfig")
 }
 
-func (chSpec *RabbitmqChannelConfigSpec) validate(ctx context.Context) *apis.FieldError {
+func (chSpec *RabbitmqChannelConfigSpec) validate() *apis.FieldError {
 	if chSpec.Parallelism == nil {
 		return nil
 	}

--- a/pkg/apis/sources/v1alpha1/rabbitmq_validation_test.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_validation_test.go
@@ -30,6 +30,7 @@ var (
 		Brokers: "amqp://guest:guest@localhost:5672/",
 		Topic:   "logs_topic",
 		ExchangeConfig: RabbitmqSourceExchangeConfigSpec{
+			Name:       "an-exchange",
 			Type:       "topic",
 			Durable:    true,
 			AutoDelete: false,
@@ -290,6 +291,40 @@ func TestRabbitmqSourceCheckChannelParallelismValue(t *testing.T) {
 				if tc.allowed != (err == nil) {
 					t.Fatalf("Unexpected parallelism value check. Expected %v. Actual %v", tc.allowed, err)
 				}
+			}
+		})
+	}
+}
+
+func TestRabbitmqSourceExchangeConfig(t *testing.T) {
+	testCases := map[string]struct {
+		spec                 *RabbitmqSourceExchangeConfigSpec
+		predeclared, allowed bool
+	}{
+		"not allowed when predeclared set to false and no exchange name set": {
+			spec:        &RabbitmqSourceExchangeConfigSpec{},
+			predeclared: false,
+			allowed:     false,
+		},
+		"allowed when predeclared set to true and no exchange name set": {
+			spec:        &RabbitmqSourceExchangeConfigSpec{},
+			predeclared: true,
+			allowed:     true,
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			src := &RabbitmqSource{
+				Spec: RabbitmqSourceSpec{
+					ExchangeConfig: *tc.spec,
+					Predeclared:    tc.predeclared,
+				},
+			}
+
+			err := src.Validate(context.TODO())
+			if tc.allowed != (err == nil) {
+				t.Fatalf("ExchangeConfig validation result incorrect. Expected %v. Actual %v", tc.allowed, err)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

- :gift: - queue name is always required; exchange name is required when spec.predeclared is false

/kind enhancement

