### PR TITLE
Merges with up-to-date main before running tests

### DIFF
--- a/.github/workflows/kind-conformance-standalone.yaml
+++ b/.github/workflows/kind-conformance-standalone.yaml
@@ -54,6 +54,7 @@ jobs:
         path: ./src/knative.dev/${{ github.event.repository.name }}
 
     - name: Merge upstream
+      working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       if: github.event_name == 'pull_request'
       run: |
         if ! git config user.name > /dev/null; then

--- a/.github/workflows/kind-conformance-standalone.yaml
+++ b/.github/workflows/kind-conformance-standalone.yaml
@@ -53,6 +53,20 @@ jobs:
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
 
+    - name: Merge upstream
+      if: github.event_name == 'pull_request'
+      run: |
+        if ! git config user.name > /dev/null; then
+          git config user.name "John Doe"
+        fi
+        if ! git config user.email > /dev/null; then
+          git config user.email "johndoe@localhost"
+        fi
+        git remote add upstream https://github.com/${{ github.repository }}.git
+        git fetch upstream ${{ github.base_ref }}
+        git pull --no-rebase --no-commit upstream ${{ github.base_ref }}
+      shell: bash
+
     - name: Run conformance tests & install all required deps
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       run: |

--- a/.github/workflows/kind-conformance-standalone.yaml
+++ b/.github/workflows/kind-conformance-standalone.yaml
@@ -52,6 +52,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
+        fetch-depth: 0
 
     - name: Merge upstream
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}

--- a/.github/workflows/kind-conformance.yaml
+++ b/.github/workflows/kind-conformance.yaml
@@ -54,6 +54,7 @@ jobs:
         path: ./src/knative.dev/${{ github.event.repository.name }}
 
     - name: Merge upstream
+      working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       if: github.event_name == 'pull_request'
       run: |
         if ! git config user.name > /dev/null; then

--- a/.github/workflows/kind-conformance.yaml
+++ b/.github/workflows/kind-conformance.yaml
@@ -53,6 +53,20 @@ jobs:
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
 
+    - name: Merge upstream
+      if: github.event_name == 'pull_request'
+      run: |
+        if ! git config user.name > /dev/null; then
+          git config user.name "John Doe"
+        fi
+        if ! git config user.email > /dev/null; then
+          git config user.email "johndoe@localhost"
+        fi
+        git remote add upstream https://github.com/${{ github.repository }}.git
+        git fetch upstream ${{ github.base_ref }}
+        git pull --no-rebase --no-commit upstream ${{ github.base_ref }}
+      shell: bash
+
     - name: Run conformance tests & install all required deps
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       run: |

--- a/.github/workflows/kind-conformance.yaml
+++ b/.github/workflows/kind-conformance.yaml
@@ -52,6 +52,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
+        fetch-depth: 0
 
     - name: Merge upstream
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -50,6 +50,20 @@ jobs:
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
 
+    - name: Merge upstream
+      if: github.event_name == 'pull_request'
+      run: |
+        if ! git config user.name > /dev/null; then
+          git config user.name "John Doe"
+        fi
+        if ! git config user.email > /dev/null; then
+          git config user.email "johndoe@localhost"
+        fi
+        git remote add upstream https://github.com/${{ github.repository }}.git
+        git fetch upstream ${{ github.base_ref }}
+        git pull --no-rebase --no-commit upstream ${{ github.base_ref }}
+      shell: bash
+
     - name: Setup a local KIND Cluster with everything that is needed to run tests
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       run: |

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -49,6 +49,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
+        fetch-depth: 0
 
     - name: Merge upstream
       working-directory: ./src/knative.dev/${{ github.event.repository.name }}

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -51,6 +51,7 @@ jobs:
         path: ./src/knative.dev/${{ github.event.repository.name }}
 
     - name: Merge upstream
+      working-directory: ./src/knative.dev/${{ github.event.repository.name }}
       if: github.event_name == 'pull_request'
       run: |
         if ! git config user.name > /dev/null; then


### PR DESCRIPTION
- 🧹  pulls and merges latest changes from main before running e2e and conformance tests. This is already done for unit-tests.

/kind cleanup

