### PR TITLE
Rename rmqsource spec.brokers to broker

### DIFF
--- a/config/source/300-rabbitmqsource.yaml
+++ b/config/source/300-rabbitmqsource.yaml
@@ -50,8 +50,8 @@ spec:
               backoffPolicy:
                 description: BackoffPolicy is the retry backoff policy (linear, exponential).
                 type: string
-              brokers:
-                description: Brokers are the Rabbitmq servers the consumer will connect
+              broker:
+                description: Broker are the Rabbitmq servers the consumer will connect
                   to.
                 type: string
               channelConfig:
@@ -218,7 +218,7 @@ spec:
                   up our sources
                 type: string
             required:
-            - brokers
+            - broker
             type: object
           status:
             properties:

--- a/pkg/apis/sources/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_types.go
@@ -96,9 +96,9 @@ type RabbitmqSourceQueueConfigSpec struct {
 }
 
 type RabbitmqSourceSpec struct {
-	// Brokers are the Rabbitmq servers the consumer will connect to.
+	// Broker are the Rabbitmq servers the consumer will connect to.
 	// +required
-	Brokers string `json:"brokers"`
+	Broker string `json:"broker"`
 	// User for rabbitmq connection
 	// +optional
 	User SecretValueFromSource `json:"user,omitempty"`

--- a/pkg/apis/sources/v1alpha1/rabbitmq_validation_test.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_validation_test.go
@@ -27,8 +27,8 @@ import (
 var (
 	defaultParallelism = 1
 	fullSpec           = RabbitmqSourceSpec{
-		Brokers: "amqp://guest:guest@localhost:5672/",
-		Topic:   "logs_topic",
+		Broker: "amqp://guest:guest@localhost:5672/",
+		Topic:  "logs_topic",
 		ExchangeConfig: RabbitmqSourceExchangeConfigSpec{
 			Name:       "an-exchange",
 			Type:       "topic",
@@ -76,10 +76,10 @@ func TestRabbitmqSourceCheckImmutableFields(t *testing.T) {
 			},
 			allowed: false,
 		},
-		"Brokers changed": {
+		"Broker changed": {
 			orig: &fullSpec,
 			updated: RabbitmqSourceSpec{
-				Brokers:            "broker1",
+				Broker:             "broker1",
 				Sink:               fullSpec.Sink,
 				ServiceAccountName: fullSpec.ServiceAccountName,
 			},
@@ -230,7 +230,7 @@ func TestRabbitmqSourceCheckChannelParallelismValue(t *testing.T) {
 		},
 		"valid channel parallelism value update": {
 			spec: &RabbitmqSourceSpec{
-				Brokers:        fullSpec.Brokers,
+				Broker:         fullSpec.Broker,
 				Topic:          fullSpec.Topic,
 				ExchangeConfig: fullSpec.ExchangeConfig,
 				QueueConfig: RabbitmqSourceQueueConfigSpec{

--- a/pkg/reconciler/source/resources/receive_adapter.go
+++ b/pkg/reconciler/source/resources/receive_adapter.go
@@ -43,7 +43,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 	env := []corev1.EnvVar{
 		{
 			Name:  "RABBITMQ_BROKERS",
-			Value: args.Source.Spec.Brokers,
+			Value: args.Source.Spec.Broker,
 		},
 		{
 			Name:  "RABBITMQ_TOPIC",

--- a/pkg/reconciler/source/resources/receive_adapter_test.go
+++ b/pkg/reconciler/source/resources/receive_adapter_test.go
@@ -55,7 +55,7 @@ func TestMakeReceiveAdapter(t *testing.T) {
 				Spec: v1alpha12.RabbitmqSourceSpec{
 					ServiceAccountName: "source-svc-acct",
 					Topic:              "topic",
-					Brokers:            "amqp://guest:guest@localhost:5672/",
+					Broker:             "amqp://guest:guest@localhost:5672/",
 					User: v1alpha12.SecretValueFromSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{

--- a/samples/source/500-source.yaml
+++ b/samples/source/500-source.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rabbitmq-source
   namespace: source-demo
 spec:
-  brokers: "rabbitmq:5672/"
+  broker: "rabbitmq:5672/"
   topic: ""
   user:
     secretKeyRef:

--- a/samples/source/README.md
+++ b/samples/source/README.md
@@ -129,7 +129,7 @@ metadata:
   name: rabbitmq-source
   namespace: source-demo
 spec:
-  brokers: "rabbitmq:5672/"
+  broker: "rabbitmq:5672/"
   topic: ""
   user:
     secretKeyRef:

--- a/test/e2e/config/source/rabbitmq-source.yaml
+++ b/test/e2e/config/source/rabbitmq-source.yaml
@@ -18,7 +18,7 @@ metadata:
   name: rabbitmq-source
   namespace: {{ .namespace }}
 spec:
-  brokers: "rabbitmqc.{{ .namespace }}:5672/"
+  broker: "rabbitmqc.{{ .namespace }}:5672/"
   topic: ""
   connectionSecret:
     name: "rabbitmqc-default-user"

--- a/test/e2e/config/sourcevhost/rabbitmq-source-vhost.yaml
+++ b/test/e2e/config/sourcevhost/rabbitmq-source-vhost.yaml
@@ -18,7 +18,7 @@ metadata:
   name: rabbitmq-source-vhost
   namespace: {{ .namespace }}
 spec:
-  brokers: "rabbitmqc.{{ .namespace }}:5672/"
+  broker: "rabbitmqc.{{ .namespace }}:5672/"
   vhost: "test-vhost"
   topic: ""
   connectionSecret:


### PR DESCRIPTION
# Changes

- :broom: rmqsource takes in a single rmq server url, not multiple

/kind cleanup

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup

Relates to #581 
