### PR TITLE
Remove spec.topic in RabbitmqSource

### DIFF
--- a/config/source/300-rabbitmqsource.yaml
+++ b/config/source/300-rabbitmqsource.yaml
@@ -188,9 +188,6 @@ spec:
                       will be resolved using the base URI retrieved from Ref.
                     type: string
                 type: object
-              topic:
-                description: Topic topic to consume messages from
-                type: string
               user:
                 description: User for rabbitmq connection
                 properties:

--- a/docs/source-example.yaml
+++ b/docs/source-example.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: rabbitsource
 spec:
   brokers: RABBITMQ_BROKERS
-  topic: RABBITMQ_TOPIC
   retry: 5
   backoffPolicy: "linear"
   backoffDelay: "50ms"

--- a/docs/source.md
+++ b/docs/source.md
@@ -117,7 +117,7 @@ Event attributes
 | Attribute | Value  | Notes  |
 |-----------|--------|--------|
 | `type` | `dev.knative.rabbitmq.event` | |
-| `source` | `/apis/v1/namespace/*$NS*/rabbitmqsources/*$NAME*#*$TOPIC*` | `NS`, `NAME` and `TOPIC` are derived from the source configuration |
+| `source` | `/apis/v1/namespace/*$NS*/rabbitmqsources/*$NAME*#*$QUEUE_NAME*` | `NS`, `NAME` and `QUEUE_NAME` are derived from the source configuration |
 | `id` | A unique ID | This uses the `MessageId` if available, and a UUID otherwise |
 | `subject` | The ID of the message | Empty string if no message ID is present |
 | `datacontenttype` | `application/json` | Currently static |
@@ -165,7 +165,6 @@ Source parameters
 | `spec.predeclared` | Defines if the source should try to create new queue or use predeclared one (Boolean) |
 | `user.secretKeyRef` | Username for Broker authentication; field `key` in a Kubernetes Secret named `name` |
 | `password.secretKeyRef` | Password for Broker authentication; field `key` in a Kubernetes Secret named `name` |
-| `topic` | The topic for the exchange |
 | `exchangeConfig` | Settings for the exchange |
 | `exchangeConfig.type` | [Exchange type](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchanges). Can be `fanout`, `direct`, `topic`, `match` or `headers` |
 | `exchangeConfig.durable` * | Boolean |

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -66,7 +66,6 @@ type adapterConfig struct {
 	adapter.EnvConfig
 
 	Brokers        string        `envconfig:"RABBITMQ_BROKERS" required:"true"`
-	Topic          string        `envconfig:"RABBITMQ_TOPIC" required:"true"`
 	User           string        `envconfig:"RABBITMQ_USER" required:"false"`
 	Password       string        `envconfig:"RABBITMQ_PASSWORD" required:"false"`
 	Vhost          string        `envconfig:"RABBITMQ_VHOST" required:"false"`

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -124,7 +124,6 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 
 			a := &Adapter{
 				config: &adapterConfig{
-					Topic:   "topic",
 					Brokers: "amqp://guest:guest@localhost:5672/",
 					ExchangeConfig: ExchangeConfig{
 						TypeOf:     "topic",
@@ -205,7 +204,6 @@ func TestAdapter_CreateConn(t *testing.T) {
 
 	a := &Adapter{
 		config: &adapterConfig{
-			Topic:   "",
 			Brokers: "amqp://localhost:5672/%2f",
 			ExchangeConfig: ExchangeConfig{
 				TypeOf:     "direct",
@@ -250,7 +248,6 @@ func TestAdapter_CreateChannel(t *testing.T) {
 
 	a := &Adapter{
 		config: &adapterConfig{
-			Topic:   "",
 			Brokers: "amqp://localhost:5672/%2f",
 			ExchangeConfig: ExchangeConfig{
 				TypeOf:     "direct",
@@ -299,7 +296,6 @@ func TestAdapter_StartAmqpClient(t *testing.T) {
 
 	a := &Adapter{
 		config: &adapterConfig{
-			Topic:       "",
 			Brokers:     "amqp://localhost:5674/%2f",
 			Predeclared: true,
 			QueueConfig: QueueConfig{
@@ -440,7 +436,6 @@ func TestAdapter_PollForMessages(t *testing.T) {
 
 	a := &Adapter{
 		config: &adapterConfig{
-			Topic:   "topic",
 			Brokers: "amqp://guest:guest@localhost:5672/",
 			ExchangeConfig: ExchangeConfig{
 				Name:       "Test-exchange",

--- a/pkg/adapter/message.go
+++ b/pkg/adapter/message.go
@@ -174,7 +174,7 @@ func convertToCloudEvent(event *cloudevents.Event, msg wabbit.Delivery, a *Adapt
 	}
 
 	event.SetType(sourcesv1alpha1.RabbitmqEventType)
-	event.SetSource(sourcesv1alpha1.RabbitmqEventSource(a.config.Namespace, a.config.Name, a.config.Topic))
+	event.SetSource(sourcesv1alpha1.RabbitmqEventSource(a.config.Namespace, a.config.Name, a.config.QueueConfig.Name))
 	event.SetSubject(event.ID())
 	event.SetTime(msg.Timestamp())
 	err := event.SetData(msg.ContentType(), msg.Body())

--- a/pkg/apis/sources/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_types.go
@@ -105,9 +105,6 @@ type RabbitmqSourceSpec struct {
 	// Password for rabbitmq connection
 	// +optional
 	Password SecretValueFromSource `json:"password,omitempty"`
-	// Topic topic to consume messages from
-	// +required
-	Topic string `json:"topic,omitempty"`
 	// Predeclared defines if channels and queues are already predeclared and shouldn't be recreated.
 	// This should be used in case the user does not have permission to declare new queues and channels in
 	// RabbitMQ cluster
@@ -160,8 +157,10 @@ const (
 	RabbitmqEventType = "dev.knative.rabbitmq.event"
 )
 
-func RabbitmqEventSource(namespace, rabbitmqSourceName, topic string) string {
-	return fmt.Sprintf("/apis/v1/namespaces/%s/rabbitmqsources/%s#%s", namespace, rabbitmqSourceName, topic)
+// RabbitmqEventSource returns cloud event attribute 'source' for messages published by a rabbitmqsource
+// format is '/apis/v1/namespace/NAMESPACE/rabbitmqsources/NAME#QUEUE_NAME'
+func RabbitmqEventSource(namespace, rabbitmqSourceName, qName string) string {
+	return fmt.Sprintf("/apis/v1/namespaces/%s/rabbitmqsources/%s#%s", namespace, rabbitmqSourceName, qName)
 }
 
 type RabbitmqSourceStatus struct {

--- a/pkg/apis/sources/v1alpha1/rabbitmq_validation_test.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_validation_test.go
@@ -28,7 +28,6 @@ var (
 	defaultParallelism = 1
 	fullSpec           = RabbitmqSourceSpec{
 		Broker: "amqp://guest:guest@localhost:5672/",
-		Topic:  "logs_topic",
 		ExchangeConfig: RabbitmqSourceExchangeConfigSpec{
 			Name:       "an-exchange",
 			Type:       "topic",
@@ -67,15 +66,6 @@ func TestRabbitmqSourceCheckImmutableFields(t *testing.T) {
 			updated: fullSpec,
 			allowed: true,
 		},
-		"Topic changed": {
-			orig: &fullSpec,
-			updated: RabbitmqSourceSpec{
-				Topic:              "some-other-topic",
-				Sink:               fullSpec.Sink,
-				ServiceAccountName: fullSpec.ServiceAccountName,
-			},
-			allowed: false,
-		},
 		"Broker changed": {
 			orig: &fullSpec,
 			updated: RabbitmqSourceSpec{
@@ -88,7 +78,6 @@ func TestRabbitmqSourceCheckImmutableFields(t *testing.T) {
 		"Sink.APIVersion changed": {
 			orig: &fullSpec,
 			updated: RabbitmqSourceSpec{
-				Topic: fullSpec.Topic,
 				Sink: &duckv1.Destination{
 					Ref: &duckv1.KReference{
 						APIVersion: "some-other-api-version",
@@ -104,7 +93,6 @@ func TestRabbitmqSourceCheckImmutableFields(t *testing.T) {
 		"Sink.Kind changed": {
 			orig: &fullSpec,
 			updated: RabbitmqSourceSpec{
-				Topic: fullSpec.Topic,
 				Sink: &duckv1.Destination{
 					Ref: &duckv1.KReference{
 						APIVersion: fullSpec.Sink.Ref.APIVersion,
@@ -120,7 +108,6 @@ func TestRabbitmqSourceCheckImmutableFields(t *testing.T) {
 		"Sink.Namespace changed": {
 			orig: &fullSpec,
 			updated: RabbitmqSourceSpec{
-				Topic: fullSpec.Topic,
 				Sink: &duckv1.Destination{
 					Ref: &duckv1.KReference{
 						APIVersion: fullSpec.Sink.Ref.APIVersion,
@@ -136,7 +123,6 @@ func TestRabbitmqSourceCheckImmutableFields(t *testing.T) {
 		"Sink.Name changed": {
 			orig: &fullSpec,
 			updated: RabbitmqSourceSpec{
-				Topic: fullSpec.Topic,
 				Sink: &duckv1.Destination{
 					Ref: &duckv1.KReference{
 						APIVersion: fullSpec.Sink.Ref.APIVersion,
@@ -152,7 +138,6 @@ func TestRabbitmqSourceCheckImmutableFields(t *testing.T) {
 		"ServiceAccountName changed": {
 			orig: &fullSpec,
 			updated: RabbitmqSourceSpec{
-				Topic: fullSpec.Topic,
 				Sink: &duckv1.Destination{
 					Ref: &duckv1.KReference{
 						APIVersion: fullSpec.Sink.Ref.APIVersion,
@@ -231,7 +216,6 @@ func TestRabbitmqSourceCheckChannelParallelismValue(t *testing.T) {
 		"valid channel parallelism value update": {
 			spec: &RabbitmqSourceSpec{
 				Broker:         fullSpec.Broker,
-				Topic:          fullSpec.Topic,
 				ExchangeConfig: fullSpec.ExchangeConfig,
 				QueueConfig: RabbitmqSourceQueueConfigSpec{
 					Name:       "",

--- a/pkg/reconciler/source/rabbitmqsource.go
+++ b/pkg/reconciler/source/rabbitmqsource.go
@@ -286,7 +286,7 @@ func (r *Reconciler) UpdateFromMetricsConfigMap(cfg *corev1.ConfigMap) {
 func (r *Reconciler) createCloudEventAttributes(src *v1alpha1.RabbitmqSource) []duckv1.CloudEventAttributes {
 	ceAttribute := duckv1.CloudEventAttributes{
 		Type:   v1alpha1.RabbitmqEventType,
-		Source: v1alpha1.RabbitmqEventSource(src.Namespace, src.Name, src.Spec.Topic),
+		Source: v1alpha1.RabbitmqEventSource(src.Namespace, src.Name, src.Spec.QueueConfig.Name),
 	}
 	return []duckv1.CloudEventAttributes{ceAttribute}
 }

--- a/pkg/reconciler/source/resources/receive_adapter.go
+++ b/pkg/reconciler/source/resources/receive_adapter.go
@@ -46,10 +46,6 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 			Value: args.Source.Spec.Broker,
 		},
 		{
-			Name:  "RABBITMQ_TOPIC",
-			Value: args.Source.Spec.Topic,
-		},
-		{
 			Name: "RABBITMQ_USER",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: args.Source.Spec.User.SecretKeyRef,

--- a/pkg/reconciler/source/resources/receive_adapter_test.go
+++ b/pkg/reconciler/source/resources/receive_adapter_test.go
@@ -54,7 +54,6 @@ func TestMakeReceiveAdapter(t *testing.T) {
 				},
 				Spec: v1alpha12.RabbitmqSourceSpec{
 					ServiceAccountName: "source-svc-acct",
-					Topic:              "topic",
 					Broker:             "amqp://guest:guest@localhost:5672/",
 					User: v1alpha12.SecretValueFromSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
@@ -158,10 +157,6 @@ func TestMakeReceiveAdapter(t *testing.T) {
 										{
 											Name:  "RABBITMQ_BROKERS",
 											Value: "amqp://guest:guest@localhost:5672/",
-										},
-										{
-											Name:  "RABBITMQ_TOPIC",
-											Value: "topic",
 										},
 										{
 											Name: "RABBITMQ_USER",

--- a/samples/source/500-source.yaml
+++ b/samples/source/500-source.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: source-demo
 spec:
   broker: "rabbitmq:5672/"
-  topic: ""
   user:
     secretKeyRef:
       name: rabbitmq-default-user

--- a/samples/source/README.md
+++ b/samples/source/README.md
@@ -130,7 +130,6 @@ metadata:
   namespace: source-demo
 spec:
   broker: "rabbitmq:5672/"
-  topic: ""
   user:
     secretKeyRef:
       name: rabbitmq-default-user

--- a/test/e2e/config/source/rabbitmq-source.yaml
+++ b/test/e2e/config/source/rabbitmq-source.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: {{ .namespace }}
 spec:
   broker: "rabbitmqc.{{ .namespace }}:5672/"
-  topic: ""
   connectionSecret:
     name: "rabbitmqc-default-user"
   user:

--- a/test/e2e/config/sourcevhost/rabbitmq-source-vhost.yaml
+++ b/test/e2e/config/sourcevhost/rabbitmq-source-vhost.yaml
@@ -20,7 +20,6 @@ metadata:
 spec:
   broker: "rabbitmqc.{{ .namespace }}:5672/"
   vhost: "test-vhost"
-  topic: ""
   connectionSecret:
     name: "secret-basic-auth"
   user:


### PR DESCRIPTION
# Changes

- :broom: remove spec.topic from RabbitmqSource. Name of exchange can be configured in `spec.exchangeConfig.name` and `topic` as a property does not make sense
- msgs published by rmqsource will now have the source attribute set  to `/apis/v1/namespace/*$NS*/rabbitmqsources/*$NAME*#*$QUEUE_NAME*`where `QUEUE_NAME` used to be TOPIC


/kind cleanup
/kind enhancement

