### PR TITLE
Make rabbitmqsource spec.sink a required property

### DIFF
--- a/config/source/300-rabbitmqsource.yaml
+++ b/config/source/300-rabbitmqsource.yaml
@@ -152,7 +152,7 @@ spec:
                 type: string
               sink:
                 description: Sink is a reference to an object that will resolve to
-                  a domain name to use as the sink.
+                  a domain name to use as the sink. Required property.
                 properties:
                   ref:
                     description: Ref points to an Addressable.
@@ -216,6 +216,7 @@ spec:
                 type: string
             required:
             - broker
+            - sink
             type: object
           status:
             properties:

--- a/pkg/apis/sources/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_types.go
@@ -137,8 +137,9 @@ type RabbitmqSourceSpec struct {
 	// +required
 	QueueConfig RabbitmqSourceQueueConfigSpec `json:"queueConfig,omitempty"`
 	// Sink is a reference to an object that will resolve to a domain name to use as the sink.
-	// +optional
-	Sink *duckv1.Destination `json:"sink,omitempty"`
+	// Required property.
+	// +required
+	Sink *duckv1.Destination `json:"sink"`
 	// ServiceAccountName is the name of the ServiceAccount that will be used to run the Receive
 	// Adapter Deployment.
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :broom: Make rabbitmqsource spec.sink a required property

Relates to #581 

/kind enhancement

