### PR TITLE
Set default for rmqsource in CRD instead of webhook

### DIFF
--- a/config/source/300-rabbitmqsource.yaml
+++ b/config/source/300-rabbitmqsource.yaml
@@ -61,6 +61,7 @@ spec:
                     description: Channel Qos global property
                     type: boolean
                   parallelism:
+                    default: 1
                     description: Sets the Channel's Prefetch count and number of Workers
                       to consume simultaneously from it
                     maximum: 1000

--- a/pkg/apis/sources/v1alpha1/rabbitmq_defaults.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_defaults.go
@@ -18,13 +18,4 @@ package v1alpha1
 
 import "context"
 
-func (r *RabbitmqSource) SetDefaults(ctx context.Context) {
-	r.Spec.ChannelConfig.SetDefaults(ctx)
-}
-
-func (chConf *RabbitmqChannelConfigSpec) SetDefaults(ctx context.Context) {
-	if chConf.Parallelism == nil {
-		defaultParallelism := 1
-		chConf.Parallelism = &defaultParallelism
-	}
-}
+func (r *RabbitmqSource) SetDefaults(ctx context.Context) {}

--- a/pkg/apis/sources/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_types.go
@@ -59,6 +59,7 @@ type RabbitmqChannelConfigSpec struct {
 	// +optional
 	// +kubebuilder:validation:Minimum:=1
 	// +kubebuilder:validation:Maximum:=1000
+	// +kubebuilder:default:=1
 	Parallelism *int `json:"parallelism,omitempty"`
 	// Channel Qos global property
 	// +optional


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- Set default for rmqsource in CRD instead of webhook. It's cleaner and more k8s idiomatic this way.

/kind enhancement

