### PR TITLE
Bump min k8s version + dependency updates

### DIFF
--- a/.github/workflows/kind-conformance-standalone.yaml
+++ b/.github/workflows/kind-conformance-standalone.yaml
@@ -19,17 +19,17 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.21.2
         - v1.22.1
+        - v1.23.3
 
         # Map between K8S and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1
         include:
-        - k8s-version: v1.21.2
-          kind-image-sha: sha256:9d07ff05e4afefbba983fac311807b3c17a5f36e7061f6cb7e2ba756255b2be4
         - k8s-version: v1.22.1
           kind-image-sha: sha256:100b3558428386d1372591f8d62add85b900538d94db8e455b66ebaf05a3ca3a
+        - k8s-version: v1.23.3
+          kind-image-sha: sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
     env:
       GOPATH: ${{ github.workspace }}
 

--- a/.github/workflows/kind-conformance.yaml
+++ b/.github/workflows/kind-conformance.yaml
@@ -19,17 +19,17 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.21.2
         - v1.22.1
+        - v1.23.3
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1
         include:
-        - k8s-version: v1.21.2
-          kind-image-sha: sha256:9d07ff05e4afefbba983fac311807b3c17a5f36e7061f6cb7e2ba756255b2be4
         - k8s-version: v1.22.1
           kind-image-sha: sha256:100b3558428386d1372591f8d62add85b900538d94db8e455b66ebaf05a3ca3a
+        - k8s-version: v1.23.3
+          kind-image-sha: sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
     env:
       GOPATH: ${{ github.workspace }}
 

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -15,9 +15,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.21.2
         - v1.22.1
-
+        - v1.23.3
         knative-version:
         - 1.0.2
         - 1.1.0
@@ -26,10 +25,10 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1
         include:
-        - k8s-version: v1.21.2
-          kind-image-sha: sha256:9d07ff05e4afefbba983fac311807b3c17a5f36e7061f6cb7e2ba756255b2be4
         - k8s-version: v1.22.1
           kind-image-sha: sha256:100b3558428386d1372591f8d62add85b900538d94db8e455b66ebaf05a3ca3a
+        - k8s-version: v1.23.3
+          kind-image-sha: sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
     env:
       GOPATH: ${{ github.workspace }}
 

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ releases-envsubst:
 
 KUBECTL_RELEASES := https://github.com/kubernetes/kubernetes/tags
 # Keep this in sync with KIND_K8S_VERSION
-KUBECTL_VERSION := 1.21.9
+KUBECTL_VERSION := 1.22.1
 KUBECTL_BIN := kubectl-$(KUBECTL_VERSION)-$(platform)-amd64
 KUBECTL_URL := https://storage.googleapis.com/kubernetes-release/release/v$(KUBECTL_VERSION)/bin/$(platform)/amd64/kubectl
 KUBECTL := $(LOCAL_BIN)/$(KUBECTL_BIN)
@@ -282,11 +282,11 @@ KO_DOCKER_REPO := kind.local
 envrc::
 	@echo 'export KO_DOCKER_REPO="$(KO_DOCKER_REPO)"'
 export KO_DOCKER_REPO
-MIN_SUPPORTED_K8S_VERSION := 1.21.2
+MIN_SUPPORTED_K8S_VERSION := 1.22.1
 KIND_K8S_VERSION ?= $(MIN_SUPPORTED_K8S_VERSION)
 export KIND_K8S_VERSION
 # Find the corresponding version digest in https://github.com/kubernetes-sigs/kind/releases
-KIND_K8S_DIGEST ?= sha256:9d07ff05e4afefbba983fac311807b3c17a5f36e7061f6cb7e2ba756255b2be4
+KIND_K8S_DIGEST ?= sha256:100b3558428386d1372591f8d62add85b900538d94db8e455b66ebaf05a3ca3a
 export KIND_K8S_DIGEST
 
 .PHONY: kind-cluster

--- a/go.mod
+++ b/go.mod
@@ -30,10 +30,10 @@ require (
 	k8s.io/client-go v0.23.5
 	k8s.io/code-generator v0.23.5
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65
-	knative.dev/eventing v0.30.1-0.20220406140645-dcdd9e0518d7
-	knative.dev/hack v0.0.0-20220401031746-a75ca495e7f4
-	knative.dev/pkg v0.0.0-20220406185144-dcd5d7c8a516
-	knative.dev/reconciler-test v0.0.0-20220406195245-94576b8fe1ae
+	knative.dev/eventing v0.30.1-0.20220408112246-5accb7aceaf3
+	knative.dev/hack v0.0.0-20220407171644-0e0784b13cef
+	knative.dev/pkg v0.0.0-20220407210145-4d62e1dbb943
+	knative.dev/reconciler-test v0.0.0-20220408105546-649869029f6b
 	sigs.k8s.io/controller-runtime v0.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2315,6 +2315,8 @@ knative.dev/eventing v0.30.1-0.20220403190041-06f57ca75d5f h1:hPWq4qaqOtjUJFESDr
 knative.dev/eventing v0.30.1-0.20220403190041-06f57ca75d5f/go.mod h1:6hU8ayB9weJ6cqZejOjZiHkqy1PuNA2I9T32hWj2laI=
 knative.dev/eventing v0.30.1-0.20220406140645-dcdd9e0518d7 h1:cBzpa9NPYYjkF5Ez3PHBMNMojUXtWEP7JttU29dHeWs=
 knative.dev/eventing v0.30.1-0.20220406140645-dcdd9e0518d7/go.mod h1:6hU8ayB9weJ6cqZejOjZiHkqy1PuNA2I9T32hWj2laI=
+knative.dev/eventing v0.30.1-0.20220408112246-5accb7aceaf3 h1:PA76qWjIYEXxdsk54L5H0+rLYu9JqdtfddofSrkohsw=
+knative.dev/eventing v0.30.1-0.20220408112246-5accb7aceaf3/go.mod h1:EcpeHeVqNIwFrth5ghfCoNWx1AWGcWELdOGfqZgMwXk=
 knative.dev/hack v0.0.0-20220224013837-e1785985d364/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/hack v0.0.0-20220314052818-c9c3ea17a2e9/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/hack v0.0.0-20220318020218-14f832e506f8 h1:7NcKM2USd6d3Vu/jJ4QziMUEUC+Y3yJ9xqusI/Pv0y0=
@@ -2323,8 +2325,11 @@ knative.dev/hack v0.0.0-20220328133751-f06773764ce3 h1:kXLX7HS7gwQglz+p8ohdxDdO3
 knative.dev/hack v0.0.0-20220328133751-f06773764ce3/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/hack v0.0.0-20220401031746-a75ca495e7f4 h1:3r8FksGn1yd8Zv3xVrQxJgElytra1/VaVeTdN6SHAa0=
 knative.dev/hack v0.0.0-20220401031746-a75ca495e7f4/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
+knative.dev/hack v0.0.0-20220407171644-0e0784b13cef h1:tIBTdo8Ui1oVYyaQV9kup1qA3Rp9YQosS7c5fhjHnMc=
+knative.dev/hack v0.0.0-20220407171644-0e0784b13cef/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/hack/schema v0.0.0-20220314052818-c9c3ea17a2e9/go.mod h1:ffjwmdcrH5vN3mPhO8RrF2KfNnbHeCE2C60A+2cv3U0=
 knative.dev/hack/schema v0.0.0-20220328133751-f06773764ce3/go.mod h1:ffjwmdcrH5vN3mPhO8RrF2KfNnbHeCE2C60A+2cv3U0=
+knative.dev/hack/schema v0.0.0-20220407171644-0e0784b13cef/go.mod h1:ffjwmdcrH5vN3mPhO8RrF2KfNnbHeCE2C60A+2cv3U0=
 knative.dev/pkg v0.0.0-20220310195447-38af013b30ff/go.mod h1:SsH9J6Gz+CvrHmoL0TELJXmMmohqKSQ5bpJvCv+1+ZI=
 knative.dev/pkg v0.0.0-20220316002959-3a4cc56708b9/go.mod h1:3r6srDeiuiG5DXSGfIe12r2U3Tj5JeeHnQaIXPe/4Zc=
 knative.dev/pkg v0.0.0-20220318133418-7f16595277b2/go.mod h1:nKJ2L4o7or3j58eqMK843kbIM0SiYnAXXsisfEQECS8=
@@ -2338,6 +2343,8 @@ knative.dev/pkg v0.0.0-20220401214546-c2f1f3ec291f h1:1+/0tVXahb4v0bW19hewJEnf0U
 knative.dev/pkg v0.0.0-20220401214546-c2f1f3ec291f/go.mod h1:0A5D5tOLettuVoi5x+0SLGRfrvVemXXtLH247WupPJk=
 knative.dev/pkg v0.0.0-20220406185144-dcd5d7c8a516 h1:XLBqRRpCA3HmSqr6MB4oD8o0jakBQKBaTPzC/kujhEM=
 knative.dev/pkg v0.0.0-20220406185144-dcd5d7c8a516/go.mod h1:0A5D5tOLettuVoi5x+0SLGRfrvVemXXtLH247WupPJk=
+knative.dev/pkg v0.0.0-20220407210145-4d62e1dbb943 h1:eE0lLLThHkvWWqycAiJmyIIOMMeBVjZkFQTffoWLEJU=
+knative.dev/pkg v0.0.0-20220407210145-4d62e1dbb943/go.mod h1:0A5D5tOLettuVoi5x+0SLGRfrvVemXXtLH247WupPJk=
 knative.dev/reconciler-test v0.0.0-20220314160418-3b7a0d7f7b4b/go.mod h1:RX+Piu5qCWSN3ciiJCOnWDEwd9v9hawbpW73z4HgKA8=
 knative.dev/reconciler-test v0.0.0-20220317152933-ce683fafefb6 h1:r4CSiXbXtJAnFfQcUZCzMKrnuPVAe3ChLv+6sOVBtaA=
 knative.dev/reconciler-test v0.0.0-20220317152933-ce683fafefb6/go.mod h1:kqLx5ImxclqwC7SR1w+2pzuhqvkHMDVqDzEmbAixkII=
@@ -2347,6 +2354,9 @@ knative.dev/reconciler-test v0.0.0-20220331132946-4686fbf645e0 h1:6/Pxkq1x4+Czv6
 knative.dev/reconciler-test v0.0.0-20220331132946-4686fbf645e0/go.mod h1:dNSuxm0NYNN/t0zzLhdBBZsxKNDGmae92Uc53qNIRIM=
 knative.dev/reconciler-test v0.0.0-20220406195245-94576b8fe1ae h1:MZO5OC+ZdCJ3h6wN2wYSBiPUXG1XPgweI+w904B3b9Y=
 knative.dev/reconciler-test v0.0.0-20220406195245-94576b8fe1ae/go.mod h1:dNSuxm0NYNN/t0zzLhdBBZsxKNDGmae92Uc53qNIRIM=
+knative.dev/reconciler-test v0.0.0-20220407164846-93ef9639ad95/go.mod h1:dNSuxm0NYNN/t0zzLhdBBZsxKNDGmae92Uc53qNIRIM=
+knative.dev/reconciler-test v0.0.0-20220408105546-649869029f6b h1:tJ05+OZadjmFf8BlwX4ShwG9Fx9JK+2RTzxD71gy5xc=
+knative.dev/reconciler-test v0.0.0-20220408105546-649869029f6b/go.mod h1:lpugBzYOTtwVbTS+UHDG8oCBEb6mRsBnJm7Lp/Yhcq4=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/knative.dev/pkg/leaderelection/context.go
+++ b/vendor/knative.dev/pkg/leaderelection/context.go
@@ -273,7 +273,7 @@ func (ue *unopposedElector) Run(ctx context.Context) {
 
 func (ue *unopposedElector) InitialBuckets() []reconciler.Bucket {
 	return []reconciler.Bucket{
-		reconciler.UniversalBucket(),
+		ue.bkt,
 	}
 }
 

--- a/vendor/knative.dev/pkg/version/version.go
+++ b/vendor/knative.dev/pkg/version/version.go
@@ -33,7 +33,7 @@ const (
 	// NOTE: If you are changing this line, please also update the minimum kubernetes
 	// version listed here:
 	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
-	defaultMinimumVersion = "v1.21.0"
+	defaultMinimumVersion = "v1.22.0"
 )
 
 func getMinimumVersion() string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1180,7 +1180,7 @@ k8s.io/utils/internal/third_party/forked/golang/net
 k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/eventing v0.30.1-0.20220406140645-dcdd9e0518d7
+# knative.dev/eventing v0.30.1-0.20220408112246-5accb7aceaf3
 ## explicit; go 1.16
 knative.dev/eventing/pkg/adapter/v2
 knative.dev/eventing/pkg/adapter/v2/util/crstatusevent
@@ -1278,10 +1278,10 @@ knative.dev/eventing/test/test_images/event-sender
 knative.dev/eventing/test/test_images/heartbeats
 knative.dev/eventing/test/test_images/performance
 knative.dev/eventing/test/test_images/print
-# knative.dev/hack v0.0.0-20220401031746-a75ca495e7f4
+# knative.dev/hack v0.0.0-20220407171644-0e0784b13cef
 ## explicit; go 1.14
 knative.dev/hack
-# knative.dev/pkg v0.0.0-20220406185144-dcd5d7c8a516
+# knative.dev/pkg v0.0.0-20220407210145-4d62e1dbb943
 ## explicit; go 1.17
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck
@@ -1384,7 +1384,7 @@ knative.dev/pkg/webhook/json
 knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
-# knative.dev/reconciler-test v0.0.0-20220406195245-94576b8fe1ae
+# knative.dev/reconciler-test v0.0.0-20220408105546-649869029f6b
 ## explicit; go 1.17
 knative.dev/reconciler-test/cmd/eventshub
 knative.dev/reconciler-test/pkg/environment


### PR DESCRIPTION
# Changes
- bump min used k8s version to v1.22.1
- bump kubectl version to v1.22.1
- remove v1.21 from matrix testing

Includes changes from #699 