### PR TITLE
Broker and Trigger use delivery spec for dead letter messaging

### DIFF
--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -242,6 +242,7 @@ func (r *Reconciler) reconcileDLXDispatcherDeployment(ctx context.Context, b *ev
 			Broker: b,
 			Image:  r.dispatcherImage,
 			//ServiceAccountName string
+			Delivery:           b.Spec.Delivery,
 			RabbitMQSecretName: resources.SecretName(b.Name),
 			QueueName:          naming.CreateBrokerDeadLetterQueueName(b),
 			BrokerUrlSecretKey: resources.BrokerURLSecretKey,

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -1224,6 +1224,7 @@ func createDispatcherDeployment() *appsv1.Deployment {
 	}
 	args := &resources.DispatcherArgs{
 		Broker:             broker,
+		Delivery:           delivery,
 		Image:              dispatcherImage,
 		RabbitMQSecretName: rabbitBrokerSecretName,
 		QueueName:          "b.test-namespace.test-broker.dlq.broker-test-uid",

--- a/pkg/reconciler/trigger/resources/dispatcher.go
+++ b/pkg/reconciler/trigger/resources/dispatcher.go
@@ -116,6 +116,13 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 					Value: string(*args.Delivery.BackoffPolicy),
 				})
 		}
+		if args.Delivery.BackoffDelay != nil {
+			dispatcher.Env = append(dispatcher.Env,
+				corev1.EnvVar{
+					Name:  "BACKOFF_DELAY",
+					Value: *args.Delivery.BackoffDelay,
+				})
+		}
 	}
 	if parallelism, ok := args.Trigger.ObjectMeta.Annotations[ParallelismAnnotation]; ok {
 		dispatcher.Env = append(dispatcher.Env,

--- a/pkg/reconciler/trigger/resources/dispatcher_test.go
+++ b/pkg/reconciler/trigger/resources/dispatcher_test.go
@@ -26,6 +26,7 @@ import (
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 )
@@ -57,14 +58,16 @@ func TestMakeDispatcherDeployment(t *testing.T) {
 			want: deployment(),
 		},
 		{
-			name: "with retry and backoff",
+			name: "with delivery spec",
 			args: dispatcherArgs(withDelivery(&eventingduckv1.DeliverySpec{
 				Retry:         Int32Ptr(10),
 				BackoffPolicy: &exponentialBackoff,
+				BackoffDelay:  ptr.String("20s"),
 			})),
 			want: deployment(
 				withEnv(corev1.EnvVar{Name: "RETRY", Value: "10"}),
 				withEnv(corev1.EnvVar{Name: "BACKOFF_POLICY", Value: "exponential"}),
+				withEnv(corev1.EnvVar{Name: "BACKOFF_DELAY", Value: "20s"}),
 			),
 		},
 		{


### PR DESCRIPTION
- Plumbs deliverySpec.BackoffDelay through to the dispatcher

Note: The dispatcher creation for broker and trigger is very similar. Can be consolidated in a follow-up PR 

/kind bug

**Release Note**

```release-note
- backoffDelay is used when defined in Broker or Trigger delivery spec
- dead letter messaging uses the same delivery spec
```

