### PR TITLE
Adds upgrade and uninstall instructions to broker and source.

### DIFF
--- a/docs/broker/README.md
+++ b/docs/broker/README.md
@@ -7,11 +7,13 @@ RabbitMQ *is a Messaging Broker* - an intermediary for messaging. It gives your 
 # Table of Contents
 
 - [Installation](#installation)
-- [Autoscaling](#autoscaling-optional)
 - [Customizations](#customizations)
-- [Additional Resources](#additional-resources)
 - [Delivery Failures and Delivery Spec](#delivery-failures-and-delivery-spec)
 - [Troubleshooting](#troubleshooting)
+- [Next Steps](#next-steps)
+- [Additional Resources](#additional-resources)
+- [Upgrade](#upgrade)
+- [Uninstall](#uninstall)
 
 ## Installation
 ### Prerequisites
@@ -40,7 +42,7 @@ RabbitMQ *is a Messaging Broker* - an intermediary for messaging. It gives your 
 
     If a custom installation is required, refer to the [topology operator docs](https://github.com/rabbitmq/messaging-topology-operator#quickstart).
 
-### Install rabbitmq-eventing broker
+### Install eventing-rabbitmq broker
 
 Install the latest version of the [Operator based Knative RabbitMQ Broker](https://github.com/knative-sandbox/eventing-rabbitmq/releases/):
 
@@ -118,4 +120,39 @@ If the messaging topology isn't working as expected, the conditions on brokers a
 
 - [RabbitMQ Docs](https://www.rabbitmq.com/documentation.html)
 - [RabbitMQ Operator Docs](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html)
+- [RabbitMQ Operator Production Example](https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/production-ready#production-example)
 - [Knative Docs](https://knative.dev/docs/)
+
+## Upgrade
+Prior to upgrading eventing-rabbitmq, Knative and its components should be updated according to instructions [here](https://knative.dev/docs/install/upgrade/). Be sure to pay attention to any
+steps for upgrading Custom Resource Definitions (CRDs) and only upgrade one minor version at a time.
+
+Upgrade eventing-rabbitmq by applying the newer version:
+```shell
+kubectl apply --filename https://github.com/knative-sandbox/eventing-rabbitmq/releases/download/knative-v1.4.0/rabbitmq-broker.yaml
+```
+
+## Uninstall
+### Remove eventing-rabbitmq components and resources
+Use `kubectl delete --filename <installation-file>` to remove the components installed during [Installation](#install-eventing-rabbitmq-broker). For example:
+
+```shell
+kubectl delete --filename https://github.com/knative-sandbox/eventing-rabbitmq/releases/download/v0.25.0/rabbitmq-broker.yaml
+```
+
+If `ko` was used to install, can also be used for uninstallation:
+
+```
+ko delete -f config/broker/
+```
+
+### Remove RabbitMQ Cluster and Topology Operators
+
+To remove RabbitMQ cluster and topology operators, use similar `kubectl delete` commands with the files used for installation:
+
+```
+kubectl delete -f https://github.com/rabbitmq/cluster-operator/releases/latest/download/cluster-operator.yml
+```
+
+### Uninstall Knative Serving and Eventing
+Follow the instructions [here](https://knative.dev/docs/install/uninstall/#uninstalling-optional-channel-messaging-layers) to uninstall Knative components.

--- a/docs/broker/README.md
+++ b/docs/broker/README.md
@@ -124,8 +124,9 @@ If the messaging topology isn't working as expected, the conditions on brokers a
 - [Knative Docs](https://knative.dev/docs/)
 
 ## Upgrade
-Prior to upgrading eventing-rabbitmq, Knative and its components should be updated according to instructions [here](https://knative.dev/docs/install/upgrade/). Be sure to pay attention to any
+- Prior to upgrading eventing-rabbitmq, Knative and its components should be updated according to instructions [here](https://knative.dev/docs/install/upgrade/). Be sure to pay attention to any
 steps for upgrading Custom Resource Definitions (CRDs) and only upgrade one minor version at a time.
+- Upgrade [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator) and [RabbitMQ Topology Operator](https://github.com/rabbitmq/messaging-topology-operator)
 
 Upgrade eventing-rabbitmq by applying the newer version:
 ```shell

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -18,6 +18,8 @@ an existing RabbitMQ exchange, or create a new exchange if required.
 - [Configuration Options](#configuration-options)
 - [Next Steps](#next-steps)
 - [Additional Resources](#additional-resources)
+- [Upgrade](#upgrade)
+- [Uninstall](#uninstall)
 
 ## Prerequisites
 
@@ -345,3 +347,31 @@ Check out the [Source Samples Directory](../../samples/source) in this repo and 
 
 - [RabbitMQ Docs](https://www.rabbitmq.com/documentation.html)
 - [Knative Docs](https://knative.dev/docs/)
+
+## Upgrade
+Prior to upgrading eventing-rabbitmq, Knative and its components should be updated according to instructions [here](https://knative.dev/docs/install/upgrade/). Be sure to pay attention to any
+steps for upgrading Custom Resource Definitions (CRDs) and only upgrade one minor version at a time.
+
+Upgrade eventing-rabbitmq one minor version at a time while following any migration steps outlined in release notes to migrate the RabbitMQ Source CRD.
+Components and resources can be applied in a similar fashion to installation:
+
+```shell
+kubectl apply --filename https://github.com/knative-sandbox/eventing-rabbitmq/releases/download/knative-v1.4.0/rabbitmq-source.yaml
+```
+
+## Uninstall
+### Remove eventing-rabbitmq components and resources
+Use `kubectl delete --filename <installation-file>` to remove the components installed during [Installation](#installation). For example:
+
+```shell
+kubectl delete --filename https://github.com/knative-sandbox/eventing-rabbitmq/releases/download/v0.25.0/rabbitmq-source.yaml
+```
+
+If `ko` was used to install, can also be used for uninstallation:
+
+```
+ko delete -f config/source/
+```
+
+### Uninstall Knative Serving and Eventing
+Follow the instructions [here](https://knative.dev/docs/install/uninstall/#uninstalling-optional-channel-messaging-layers) to uninstall Knative components.

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -349,8 +349,9 @@ Check out the [Source Samples Directory](../../samples/source) in this repo and 
 - [Knative Docs](https://knative.dev/docs/)
 
 ## Upgrade
-Prior to upgrading eventing-rabbitmq, Knative and its components should be updated according to instructions [here](https://knative.dev/docs/install/upgrade/). Be sure to pay attention to any
+- Prior to upgrading eventing-rabbitmq, Knative and its components should be updated according to instructions [here](https://knative.dev/docs/install/upgrade/). Be sure to pay attention to any
 steps for upgrading Custom Resource Definitions (CRDs) and only upgrade one minor version at a time.
+- Upgrade [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator) and [RabbitMQ Topology Operator](https://github.com/rabbitmq/messaging-topology-operator)
 
 Upgrade eventing-rabbitmq one minor version at a time while following any migration steps outlined in release notes to migrate the RabbitMQ Source CRD.
 Components and resources can be applied in a similar fashion to installation:


### PR DESCRIPTION
/kind documenation

Fixes #413 

One thing that stood out while writing the docs, the recommendation for installing the operators is a very loose "install the latest". The cluster operator doesn't follow a strict [semver](https://github.com/rabbitmq/cluster-operator/blob/main/version_guidelines.md) and expects anyone using it to read through release notes to highlight any potential impact. This repo uses specific versions of both operators during testing and we should be prescriptive of which versions users should install for a given version of `eventing-rabbitmq`. It may make sense to include the recommended versions of the operators as a part of our release notes so it doesn't get outdated in docs and users can expect a consistent experience. 