### PR TITLE
[e2e] Adds teardown step to clean up resources

### DIFF
--- a/test/e2e/direct_test.go
+++ b/test/e2e/direct_test.go
@@ -65,5 +65,6 @@ func DirectTestBroker() *feature.Feature {
 				// TODO: Use constraint matching instead of just counting number of events.
 				eventshub.StoreFromContext(ctx, "recorder").AssertAtLeast(t, 5)
 			})
+	f.Teardown("Delete feature resources", f.DeleteResources)
 	return f
 }

--- a/test/e2e/dispatcher_test.go
+++ b/test/e2e/dispatcher_test.go
@@ -59,6 +59,7 @@ func ConcurrentDispatchTest() *feature.Feature {
 			t.Fatalf("expected dispatch to happen concurrently but were sequential. time elapsed between events: %v", diff)
 		}
 	})
+	f.Teardown("Delete feature resources", f.DeleteResources)
 
 	return f
 }

--- a/test/e2e/dlq_test.go
+++ b/test/e2e/dlq_test.go
@@ -54,5 +54,6 @@ func BrokerDLQTest() *feature.Feature {
 				// TODO: Use constraint matching instead of just counting number of events.
 				eventshub.StoreFromContext(ctx, "recorder").AssertAtLeast(t, 5)
 			})
+	f.Teardown("Delete feature resources", f.DeleteResources)
 	return f
 }

--- a/test/e2e/receive_adapter_test.go
+++ b/test/e2e/receive_adapter_test.go
@@ -52,6 +52,6 @@ func ConcurrentAdapterProcessingTest() *feature.Feature {
 			t.Fatalf("expected processing to happen concurrently but were sequential. time elapsed between events: %v", diff)
 		}
 	})
-
+	f.Teardown("Delete feature resources", f.DeleteResources)
 	return f
 }

--- a/test/e2e/smoke_test_broker.go
+++ b/test/e2e/smoke_test_broker.go
@@ -27,5 +27,6 @@ func SmokeTestBroker() *feature.Feature {
 
 	f.Setup("install a broker", broker.Install())
 	f.Alpha("RabbitMQ broker").Must("goes ready", AllGoReady)
+	f.Teardown("Delete feature resources", f.DeleteResources)
 	return f
 }

--- a/test/e2e/smoke_test_broker_trigger.go
+++ b/test/e2e/smoke_test_broker_trigger.go
@@ -39,6 +39,7 @@ func SmokeTestBrokerTrigger() *feature.Feature {
 
 	f.Setup("install a broker", brokertrigger.Install())
 	f.Alpha("RabbitMQ broker").Must("goes ready", AllGoReady)
+	f.Teardown("Delete feature resources", f.DeleteResources)
 	return f
 }
 

--- a/test/e2e/source_test.go
+++ b/test/e2e/source_test.go
@@ -53,6 +53,6 @@ func DirectSourceTest() *feature.Feature {
 				// TODO: Use constraint matching instead of just counting number of events.
 				eventshub.StoreFromContext(ctx, "recorder").AssertAtLeast(t, eventsNumber)
 			})
-
+	f.Teardown("Delete feature resources", f.DeleteResources)
 	return f
 }

--- a/test/e2e/sourcevhost_test.go
+++ b/test/e2e/sourcevhost_test.go
@@ -53,6 +53,6 @@ func VHostSourceTest() *feature.Feature {
 				// TODO: Use constraint matching instead of just counting number of events.
 				eventshub.StoreFromContext(ctx, "recorder").AssertAtLeast(t, 10)
 			})
-
+	f.Teardown("Delete feature resources", f.DeleteResources)
 	return f
 }


### PR DESCRIPTION
# Changes
- 🐛  clean up resources after a test completes
- The resources controlled by RabbitMQ topology operator (Queues, Exchanges) get a finalizer added to them. Prior to these changes, the e2e test will attempt to clean out the entire namespace. This can lead to the namespace hanging in `terminating` state due to the finalizers. The resources won't get cleaned up as the `RabbitMQCluster` has already been deleted and no longer reachable.
- With these changes, we clean up the resources before deleting the namespace + RabbitMQCluster

/kind cleanup

