### PR TITLE
Updates resource limits for source controller

### DIFF
--- a/config/source/500-controller.yaml
+++ b/config/source/500-controller.yaml
@@ -54,11 +54,8 @@ spec:
                 - all
           volumeMounts:
           resources:
-            limits:
-              cpu: 100m
-              memory: 30Mi
             requests:
-              cpu: 20m
-              memory: 20Mi
+              cpu: 100m
+              memory: 100Mi
       serviceAccount: rabbitmq-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
- 🧹  Removes limit set on resources
- 🧹  Sets requests to 100m cpu and 100Mi memory

/kind enhancement

20-30Mi is too little for a controller. With these changes, this controller will be in line with the broker controller along with eventing-core controller. Users can still modify this value before installing and can also apply limits should they wish.


**Release Note**

```release-note
- resource requests for source controller increased
```


Related to #703 