### PR TITLE
switches back to DeepDerivative as deployments were aggressively updated

### DIFF
--- a/pkg/reconciler/trigger/resources/dispatcher.go
+++ b/pkg/reconciler/trigger/resources/dispatcher.go
@@ -139,6 +139,12 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 				Name:  "PARALLELISM",
 				Value: parallelism,
 			})
+	} else {
+		dispatcher.Env = append(dispatcher.Env,
+			corev1.EnvVar{
+				Name:  "PARALLELISM",
+				Value: "1",
+			})
 	}
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/trigger/resources/dispatcher_test.go
+++ b/pkg/reconciler/trigger/resources/dispatcher_test.go
@@ -56,7 +56,7 @@ func TestMakeDispatcherDeployment(t *testing.T) {
 		{
 			name: "base",
 			args: dispatcherArgs(),
-			want: deployment(),
+			want: deployment(withEnv(corev1.EnvVar{Name: "PARALLELISM", Value: "1"})),
 		},
 		{
 			name: "with delivery spec",
@@ -71,12 +71,16 @@ func TestMakeDispatcherDeployment(t *testing.T) {
 				withEnv(corev1.EnvVar{Name: "BACKOFF_POLICY", Value: "exponential"}),
 				withEnv(corev1.EnvVar{Name: "BACKOFF_DELAY", Value: "20s"}),
 				withEnv(corev1.EnvVar{Name: "TIMEOUT", Value: "10s"}),
+				withEnv(corev1.EnvVar{Name: "PARALLELISM", Value: "1"}),
 			),
 		},
 		{
 			name: "with dlx",
 			args: dispatcherArgs(withDLX),
-			want: deployment(deploymentNamed("testtrigger-dlx-dispatcher")),
+			want: deployment(
+				deploymentNamed("testtrigger-dlx-dispatcher"),
+				withEnv(corev1.EnvVar{Name: "PARALLELISM", Value: "1"}),
+			),
 		},
 		{
 			name: "with parallelism",

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -312,7 +312,7 @@ func (r *Reconciler) reconcileDeployment(ctx context.Context, d *v1.Deployment) 
 		return d, nil
 	} else if err != nil {
 		return nil, err
-	} else if !equality.Semantic.DeepEqual(d.Spec.Template, current.Spec.Template) {
+	} else if !equality.Semantic.DeepDerivative(d.Spec.Template, current.Spec.Template) {
 		// Don't modify the informers copy.
 		desired := current.DeepCopy()
 		desired.Spec = d.Spec


### PR DESCRIPTION
- 🐛  fixes dispatcher deployment from getting updated even without changes

/kind bug

When comparing the expected and actual, the actual has a few more defaults such as `terminationMessagePath` and `terminationMessagePolicy`. This meant that the DeepEqual was claiming unequal more frequently than what was needed. The original fix with #605  is preserved by defaulting the parallelism env variable. 


```release-note
- fixed bug in Trigger dispatcher deployment from getting updated too frequently
```

