### PR TITLE
Changes queue type to quorum

### DIFF
--- a/config/source/300-rabbitmqsource.yaml
+++ b/config/source/300-rabbitmqsource.yaml
@@ -128,9 +128,6 @@ spec:
                 properties:
                   autoDelete:
                     type: boolean
-                  durable:
-                    description: Queue is Durable or not
-                    type: boolean
                   name:
                     description: Name of the queue to bind to; required value.
                     type: string

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -55,7 +55,6 @@ type ChannelConfig struct {
 type QueueConfig struct {
 	Name       string `envconfig:"RABBITMQ_QUEUE_CONFIG_NAME" required:"true"`
 	RoutingKey string `envconfig:"RABBITMQ_ROUTING_KEY" required:"true"`
-	Durable    bool   `envconfig:"RABBITMQ_QUEUE_CONFIG_DURABLE" required:"false"`
 	AutoDelete bool   `envconfig:"RABBITMQ_QUEUE_CONFIG_AUTO_DELETE" required:"false"`
 }
 

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -131,7 +131,6 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 					},
 					QueueConfig: QueueConfig{
 						Name:       "",
-						Durable:    false,
 						AutoDelete: false,
 					},
 				},
@@ -217,7 +216,6 @@ func TestAdapter_CreateConn(t *testing.T) {
 			},
 			QueueConfig: QueueConfig{
 				Name:       "",
-				Durable:    false,
 				AutoDelete: false,
 			},
 		},
@@ -261,7 +259,6 @@ func TestAdapter_CreateChannel(t *testing.T) {
 			},
 			QueueConfig: QueueConfig{
 				Name:       "",
-				Durable:    false,
 				AutoDelete: false,
 			},
 		},
@@ -305,7 +302,6 @@ func TestAdapter_StartAmqpClient(t *testing.T) {
 			Predeclared: true,
 			QueueConfig: QueueConfig{
 				Name:       testQueue,
-				Durable:    false,
 				AutoDelete: false,
 			},
 		},
@@ -450,7 +446,6 @@ func TestAdapter_PollForMessages(t *testing.T) {
 			},
 			QueueConfig: QueueConfig{
 				Name:       "",
-				Durable:    false,
 				AutoDelete: false,
 			},
 		},
@@ -466,8 +461,7 @@ func TestAdapter_PollForMessages(t *testing.T) {
 	}
 
 	queue, err := channel.QueueDeclare("", wabbit.Option{
-		"durable": a.config.QueueConfig.Durable,
-		"delete":  a.config.QueueConfig.AutoDelete,
+		"delete": a.config.QueueConfig.AutoDelete,
 	})
 	if err != nil {
 		t.Errorf(err.Error())

--- a/pkg/apis/sources/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_types.go
@@ -89,9 +89,6 @@ type RabbitmqSourceQueueConfigSpec struct {
 	// Multiple routing keys can be specified separated by commas. e.g. key1,key2
 	// +optional
 	RoutingKey string `json:"routingKey,omitempty"`
-	// Queue is Durable or not
-	// +optional
-	Durable bool `json:"durable,omitempty"`
 	// +optional
 	AutoDelete bool `json:"autoDelete,omitempty"`
 }

--- a/pkg/apis/sources/v1alpha1/rabbitmq_validation_test.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_validation_test.go
@@ -37,7 +37,6 @@ var (
 		QueueConfig: RabbitmqSourceQueueConfigSpec{
 			Name:       "",
 			RoutingKey: "*.critical",
-			Durable:    false,
 			AutoDelete: false,
 		},
 		ChannelConfig: RabbitmqChannelConfigSpec{
@@ -220,7 +219,6 @@ func TestRabbitmqSourceCheckChannelParallelismValue(t *testing.T) {
 				QueueConfig: RabbitmqSourceQueueConfigSpec{
 					Name:       "",
 					RoutingKey: "*.critical",
-					Durable:    false,
 					AutoDelete: false,
 				},
 				ChannelConfig:      fullSpec.ChannelConfig,

--- a/pkg/rabbit/queue.go
+++ b/pkg/rabbit/queue.go
@@ -28,6 +28,8 @@ import (
 	rabbitv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 )
 
+const QuorumQueueType = "quorum"
+
 type QueueArgs struct {
 	Name                     string
 	Namespace                string
@@ -42,7 +44,6 @@ type QueueArgs struct {
 
 func NewQueue(args *QueueArgs) *rabbitv1beta1.Queue {
 	// queue configurations for broker and trigger
-	durable := true
 	autoDelete := false
 	queueName := args.Name
 	vhost := "/"
@@ -52,7 +53,6 @@ func NewQueue(args *QueueArgs) *rabbitv1beta1.Queue {
 
 	// queue configurations for source
 	if args.Source != nil {
-		durable = args.Source.Spec.QueueConfig.Durable
 		autoDelete = args.Source.Spec.QueueConfig.AutoDelete
 		queueName = args.Source.Spec.QueueConfig.Name
 		vhost = args.Source.Spec.Vhost
@@ -67,8 +67,9 @@ func NewQueue(args *QueueArgs) *rabbitv1beta1.Queue {
 		},
 		Spec: rabbitv1beta1.QueueSpec{
 			Name:                     queueName,
+			Type:                     QuorumQueueType,
 			Vhost:                    vhost,
-			Durable:                  durable,
+			Durable:                  true,
 			AutoDelete:               autoDelete,
 			RabbitmqClusterReference: *args.RabbitmqClusterReference,
 		},

--- a/pkg/rabbit/queue_test.go
+++ b/pkg/rabbit/queue_test.go
@@ -163,7 +163,6 @@ func TestNewQueue(t *testing.T) {
 					Spec: v1alpha1.RabbitmqSourceSpec{
 						QueueConfig: v1alpha1.RabbitmqSourceQueueConfigSpec{
 							Name:       "a-test-queue",
-							Durable:    false,
 							AutoDelete: false,
 						},
 						Vhost: "test",
@@ -179,8 +178,9 @@ func TestNewQueue(t *testing.T) {
 				},
 				Spec: rabbitv1beta1.QueueSpec{
 					Name:       "a-test-queue",
+					Type:       rabbit.QuorumQueueType,
 					Vhost:      "test",
-					Durable:    false,
+					Durable:    true,
 					AutoDelete: false,
 					RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{
 						ConnectionSecret: &v1.LocalObjectReference{

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -1389,6 +1389,7 @@ func createQueue(dlx bool) *rabbitv1beta1.Queue {
 		},
 		Spec: rabbitv1beta1.QueueSpec{
 			Name:       queueName,
+			Type:       rabbit.QuorumQueueType,
 			Vhost:      "/",
 			Durable:    true,
 			AutoDelete: false,

--- a/pkg/reconciler/source/resources/receive_adapter.go
+++ b/pkg/reconciler/source/resources/receive_adapter.go
@@ -91,10 +91,6 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 			Value: args.Source.Spec.QueueConfig.Name,
 		},
 		{
-			Name:  "RABBITMQ_QUEUE_CONFIG_DURABLE",
-			Value: strconv.FormatBool(args.Source.Spec.QueueConfig.Durable),
-		},
-		{
 			Name:  "RABBITMQ_QUEUE_CONFIG_AUTO_DELETE",
 			Value: strconv.FormatBool(args.Source.Spec.QueueConfig.AutoDelete),
 		},

--- a/pkg/reconciler/source/resources/receive_adapter_test.go
+++ b/pkg/reconciler/source/resources/receive_adapter_test.go
@@ -81,7 +81,6 @@ func TestMakeReceiveAdapter(t *testing.T) {
 					QueueConfig: v1alpha12.RabbitmqSourceQueueConfigSpec{
 						Name:       "",
 						RoutingKey: "*.critical",
-						Durable:    false,
 						AutoDelete: false,
 					},
 					ChannelConfig: v1alpha12.RabbitmqChannelConfigSpec{
@@ -211,10 +210,6 @@ func TestMakeReceiveAdapter(t *testing.T) {
 										{
 											Name:  "RABBITMQ_QUEUE_CONFIG_NAME",
 											Value: "",
-										},
-										{
-											Name:  "RABBITMQ_QUEUE_CONFIG_DURABLE",
-											Value: "false",
 										},
 										{
 											Name:  "RABBITMQ_QUEUE_CONFIG_AUTO_DELETE",

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -1171,6 +1171,7 @@ func createQueue() *rabbitv1beta1.Queue {
 		},
 		Spec: rabbitv1beta1.QueueSpec{
 			Name:    queueName,
+			Type:    rabbit.QuorumQueueType,
 			Vhost:   "/",
 			Durable: true,
 			RabbitmqClusterReference: rabbitv1beta1.RabbitmqClusterReference{


### PR DESCRIPTION
- 🎁  quorum queue type used for all queues
- 🗑️  Removes durable queue config option from source spec as this shouldn't be configurable for quorum queues.


/kind enhancement


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
📄  action required. The queue type has been changed from class to quorum queues. Existing broker and source deployments will be broken after the upgrade.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


/hold for release notes/doc updates