### PR TITLE
fixed cleanup logic to rabbit connections

### DIFF
--- a/cmd/ingress/main.go
+++ b/cmd/ingress/main.go
@@ -111,7 +111,7 @@ func main() {
 	if err != nil {
 		logger.Errorf("error creating RabbitMQ connections: %s, waiting for a retry", err)
 	}
-	defer rmqHelper.CleanupRabbitMQ(env.connection, env.channel, logger)
+	defer rmqHelper.CleanupRabbitMQ(env.connection, logger)
 
 	env.reporter = ingress.NewStatsReporter(env.ContainerName, kmeta.ChildName(env.PodName, uuid.New().String()))
 	connectionArgs := kncloudevents.ConnectionArgs{
@@ -233,11 +233,10 @@ func (env *envConfig) CreateRabbitMQConnections(
 		err = channel.Confirm(false)
 	}
 	if err != nil {
-		rmqHelper.CloseRabbitMQConnections(conn, channel, logger)
+		rmqHelper.CloseRabbitMQConnections(conn, logger)
 		logger.Warn("Retrying RabbitMQ connections setup")
 		go rmqHelper.SignalRetry(true)
 		return nil, nil, err
 	}
-
 	return conn, channel, nil
 }

--- a/pkg/rabbit/setup.go
+++ b/pkg/rabbit/setup.go
@@ -77,7 +77,7 @@ func (r *RabbitMQHelper) WatchRabbitMQConnections(
 	}
 	if !r.cleaningUp {
 		logger.Warn("Lost connection to RabbitMQ, reconnecting. Error: %v", zap.Error(err))
-		r.CloseRabbitMQConnections(connection, channel, logger)
+		r.CloseRabbitMQConnections(connection, logger)
 		r.SignalRetry(true)
 	}
 }
@@ -90,7 +90,7 @@ func (r *RabbitMQHelper) WaitForRetrySignal() bool {
 	return <-r.retryChannel
 }
 
-func (r *RabbitMQHelper) CloseRabbitMQConnections(connection *amqp.Connection, channel *amqp.Channel, logger *zap.SugaredLogger) {
+func (r *RabbitMQHelper) CloseRabbitMQConnections(connection *amqp.Connection, logger *zap.SugaredLogger) {
 	r.cleaningUp = true
 	if connection != nil && !connection.IsClosed() {
 		if err := connection.Close(); err != nil {
@@ -100,8 +100,8 @@ func (r *RabbitMQHelper) CloseRabbitMQConnections(connection *amqp.Connection, c
 	r.cleaningUp = false
 }
 
-func (r *RabbitMQHelper) CleanupRabbitMQ(connection *amqp.Connection, channel *amqp.Channel, logger *zap.SugaredLogger) {
+func (r *RabbitMQHelper) CleanupRabbitMQ(connection *amqp.Connection, logger *zap.SugaredLogger) {
 	r.SignalRetry(false)
-	r.CloseRabbitMQConnections(connection, channel, logger)
+	r.CloseRabbitMQConnections(connection, logger)
 	close(r.retryChannel)
 }

--- a/pkg/rabbit/setup.go
+++ b/pkg/rabbit/setup.go
@@ -27,17 +27,18 @@ type RabbitMQHelper struct {
 	retryCounter  int
 	cycleDuration time.Duration
 	cleaningUp    bool
+	retryChannel  chan bool
 }
 
-func NewRabbitMQHelper(cycleDuration time.Duration) *RabbitMQHelper {
+func NewRabbitMQHelper(cycleDuration time.Duration, retryChannel chan bool) *RabbitMQHelper {
 	return &RabbitMQHelper{
 		cycleDuration: cycleDuration,
+		retryChannel:  retryChannel,
 	}
 }
 
 func (r *RabbitMQHelper) SetupRabbitMQ(
 	RabbitMQURL string,
-	retryChannel chan<- bool,
 	logger *zap.SugaredLogger) (*amqp.Connection, *amqp.Channel, error) {
 	r.retryCounter += 1
 	var err error
@@ -53,14 +54,14 @@ func (r *RabbitMQHelper) SetupRabbitMQ(
 	if err != nil {
 		logger.Warnf("retry number %d", r.retryCounter)
 		time.Sleep(time.Second * r.cycleDuration)
-		go r.SignalRetry(retryChannel, true)
+		go r.SignalRetry(true)
 		return nil, nil, err
 	}
 
 	// if there is no error reset the retryCounter and cycle values
 	r.retryCounter = 0
 	// Wait for a channel or connection close message to rerun the RabbitMQ setup
-	go r.WatchRabbitMQConnections(conn, channel, RabbitMQURL, retryChannel, logger)
+	go r.WatchRabbitMQConnections(conn, channel, RabbitMQURL, logger)
 	return conn, channel, nil
 }
 
@@ -68,7 +69,6 @@ func (r *RabbitMQHelper) WatchRabbitMQConnections(
 	connection *amqp.Connection,
 	channel *amqp.Channel,
 	RabbitMQURL string,
-	retryChannel chan<- bool,
 	logger *zap.SugaredLogger) {
 	var err error
 	select {
@@ -76,24 +76,22 @@ func (r *RabbitMQHelper) WatchRabbitMQConnections(
 	case err = <-channel.NotifyClose(make(chan *amqp.Error)):
 	}
 	if !r.cleaningUp {
-		logger.Warn(
-			"Lost connection to RabbitMQ, reconnecting. Error: %v", zap.Error(err))
+		logger.Warn("Lost connection to RabbitMQ, reconnecting. Error: %v", zap.Error(err))
 		r.CloseRabbitMQConnections(connection, channel, logger)
-		r.SignalRetry(retryChannel, true)
+		r.SignalRetry(true)
 	}
 }
 
-func (r *RabbitMQHelper) SignalRetry(retryChannel chan<- bool, retry bool) {
-	retryChannel <- retry
+func (r *RabbitMQHelper) SignalRetry(retry bool) {
+	r.retryChannel <- retry
+}
+
+func (r *RabbitMQHelper) WaitForRetrySignal() bool {
+	return <-r.retryChannel
 }
 
 func (r *RabbitMQHelper) CloseRabbitMQConnections(connection *amqp.Connection, channel *amqp.Channel, logger *zap.SugaredLogger) {
 	r.cleaningUp = true
-	if channel != nil && !channel.IsClosed() {
-		if err := channel.Close(); err != nil {
-			logger.Error(err)
-		}
-	}
 	if connection != nil && !connection.IsClosed() {
 		if err := connection.Close(); err != nil {
 			logger.Error(err)
@@ -102,7 +100,8 @@ func (r *RabbitMQHelper) CloseRabbitMQConnections(connection *amqp.Connection, c
 	r.cleaningUp = false
 }
 
-func (r *RabbitMQHelper) CleanupRabbitMQ(connection *amqp.Connection, channel *amqp.Channel, retryChannel chan<- bool, logger *zap.SugaredLogger) {
-	r.SignalRetry(retryChannel, false)
+func (r *RabbitMQHelper) CleanupRabbitMQ(connection *amqp.Connection, channel *amqp.Channel, logger *zap.SugaredLogger) {
+	r.SignalRetry(false)
 	r.CloseRabbitMQConnections(connection, channel, logger)
+	close(r.retryChannel)
 }

--- a/pkg/rabbit/setup_test.go
+++ b/pkg/rabbit/setup_test.go
@@ -40,7 +40,7 @@ func Test_SetupRabbitMQReconnections(t *testing.T) {
 	}()
 	<-testChannel
 	// Testing a failing setup
-	conn, channel, err := rabbitMQHelper.SetupRabbitMQ("amqp://localhost:5672/%2f", logger)
+	conn, _, err := rabbitMQHelper.SetupRabbitMQ("amqp://localhost:5672/%2f", logger)
 	<-testChannel
 	if err == nil {
 		t.Error("SetupRabbitMQ should fail with the default DialFunc in testing environments")
@@ -51,5 +51,5 @@ func Test_SetupRabbitMQReconnections(t *testing.T) {
 	// Test SignalRetry func
 	rabbitMQHelper.SignalRetry(true)
 	<-testChannel
-	rabbitMQHelper.CleanupRabbitMQ(conn, channel, logger)
+	rabbitMQHelper.CleanupRabbitMQ(conn, logger)
 }


### PR DESCRIPTION
It was hanging when a connection was closed and its associated channel close method was called.
More details on [this issue](https://github.com/rabbitmq/amqp091-go/issues/88)

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Fixed bug where the broker ingress was not reconnecting after the connection or channel with RabbitMQ was closed
- 🧹 Small refactor to rabbit setup pkg

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #764 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
- 🐛 Fixed bug where the broker ingress was not reconnecting after the connection or channel with RabbitMQ was closed
```