### PR TITLE
Update conformance and most e2e tests to use RabbitmqBrokerConfig

### DIFF
--- a/config/broker/300-rabbitmqbrokerconfig.yaml
+++ b/config/broker/300-rabbitmqbrokerconfig.yaml
@@ -41,12 +41,6 @@ spec:
             type: object
           spec:
             properties:
-              queueType:
-                default: quorum
-                enum:
-                - quorum
-                - classic
-                type: string
               rabbitmqClusterReference:
                 description: RabbitmqClusterReference stores a reference to RabbitmqCluster.
                   This will get used to create resources on the RabbitMQ Broker.

--- a/pkg/apis/eventing/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/eventing/v1alpha1/rabbitmq_types.go
@@ -47,11 +47,6 @@ var _ apis.Validatable = (*RabbitmqBrokerConfig)(nil)
 type RabbitmqBrokerConfigSpec struct {
 	// RabbitmqClusterReference stores a reference to RabbitmqCluster. This will get used to create resources on the RabbitMQ Broker.
 	RabbitmqClusterReference *v1beta1.RabbitmqClusterReference `json:"rabbitmqClusterReference,omitempty"`
-
-	// +optional
-	// +kubebuilder:default:=quorum
-	// +kubebuilder:validation:Enum=quorum;classic
-	QueueType string `json:"queueType,omitempty"`
 }
 
 func (s *RabbitmqBrokerConfig) GetGroupVersionKind() schema.GroupVersionKind {

--- a/pkg/apis/eventing/v1alpha1/rabbitmq_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/rabbitmq_validation_test.go
@@ -28,7 +28,6 @@ import (
 func TestValidateRabbitmqBrokerConfig(t *testing.T) {
 	validBrokerConfig := &RabbitmqBrokerConfig{
 		Spec: RabbitmqBrokerConfigSpec{
-			QueueType: "quorum",
 			RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{
 				Namespace: "some-namespace",
 				Name:      "some-name",
@@ -49,7 +48,10 @@ func TestValidateRabbitmqBrokerConfig(t *testing.T) {
 		"spec update": {
 			newConfig: &RabbitmqBrokerConfig{
 				Spec: RabbitmqBrokerConfigSpec{
-					QueueType: "classic",
+					RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{
+						Namespace: "new-namespace",
+						Name:      "some-name",
+					},
 				},
 			},
 			wantErr:  true,
@@ -57,9 +59,7 @@ func TestValidateRabbitmqBrokerConfig(t *testing.T) {
 		},
 		"missing rabbitmqClusterReference": {
 			newConfig: &RabbitmqBrokerConfig{
-				Spec: RabbitmqBrokerConfigSpec{
-					QueueType: "classic",
-				},
+				Spec: RabbitmqBrokerConfigSpec{},
 			},
 			wantErr:  true,
 			isUpdate: false,
@@ -67,7 +67,6 @@ func TestValidateRabbitmqBrokerConfig(t *testing.T) {
 		"missing rabbitmqClusterReference.name": {
 			newConfig: &RabbitmqBrokerConfig{
 				Spec: RabbitmqBrokerConfigSpec{
-					QueueType: "classic",
 					RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{
 						Namespace: "some-namespace",
 					},
@@ -79,7 +78,6 @@ func TestValidateRabbitmqBrokerConfig(t *testing.T) {
 		"missing rabbitmqClusterReference.namespace": {
 			newConfig: &RabbitmqBrokerConfig{
 				Spec: RabbitmqBrokerConfigSpec{
-					QueueType: "classic",
 					RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{
 						Name: "some-name",
 					},
@@ -91,7 +89,6 @@ func TestValidateRabbitmqBrokerConfig(t *testing.T) {
 		"including connectionSecret": {
 			newConfig: &RabbitmqBrokerConfig{
 				Spec: RabbitmqBrokerConfigSpec{
-					QueueType: "classic",
 					RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{
 						Name:      "some-name",
 						Namespace: "some-namespace",

--- a/test/conformance/testdata/base.yaml
+++ b/test/conformance/testdata/base.yaml
@@ -9,9 +9,10 @@ metadata:
   {{ end }}
 spec:
   config:
-    apiVersion: rabbitmq.com/v1beta1
-    kind: RabbitmqCluster
-    name: rabbitbroker
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: RabbitmqBrokerConfig
+    name: rabbitmq-broker-config
+    namespace: {{ .namespace }}
   {{ if .delivery }}
   delivery:
     {{ if .delivery.deadLetterSink }}

--- a/test/conformance/testdata/broker_config.yaml
+++ b/test/conformance/testdata/broker_config.yaml
@@ -1,0 +1,9 @@
+apiVersion: eventing.knative.dev/v1alpha1
+kind: RabbitmqBrokerConfig
+metadata:
+  name: rabbitmq-broker-config
+  namespace: {{ .namespace }}
+spec:
+  rabbitmqClusterReference:
+    name: rabbitbroker
+    namespace: {{ .namespace }}

--- a/test/e2e/config/brokertrigger/broker.yaml
+++ b/test/e2e/config/brokertrigger/broker.yaml
@@ -21,6 +21,17 @@ metadata:
     eventing.knative.dev/broker.class: RabbitMQBroker
 spec:
   config:
-    apiVersion: rabbitmq.com/v1beta1
-    kind: RabbitmqCluster
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: RabbitmqBrokerConfig
+    name: rabbitmq-broker-config
+---
+
+apiVersion: eventing.knative.dev/v1alpha1
+kind: RabbitmqBrokerConfig
+metadata:
+  name: rabbitmq-broker-config
+  namespace: {{ .namespace }}
+spec:
+  rabbitmqClusterReference:
     name: rabbitmqc
+    namespace: {{ .namespace }}

--- a/test/e2e/config/dlq/broker.yaml
+++ b/test/e2e/config/dlq/broker.yaml
@@ -21,9 +21,9 @@ metadata:
     eventing.knative.dev/broker.class: RabbitMQBroker
 spec:
   config:
-    apiVersion: rabbitmq.com/v1beta1
-    kind: RabbitmqCluster
-    name: rabbitmqc
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: RabbitmqBrokerConfig
+    name: rabbitmq-broker-config
   delivery:
     deadLetterSink:
       ref:
@@ -32,3 +32,15 @@ spec:
         name: recorder
         namespace: {{ .namespace }}
     retry: 5
+
+---
+
+apiVersion: eventing.knative.dev/v1alpha1
+kind: RabbitmqBrokerConfig
+metadata:
+  name: rabbitmq-broker-config
+  namespace: {{ .namespace }}
+spec:
+  rabbitmqClusterReference:
+    name: rabbitmqc
+    namespace: {{ .namespace }}

--- a/test/e2e/config/smoke/broker/smoke.yaml
+++ b/test/e2e/config/smoke/broker/smoke.yaml
@@ -23,6 +23,17 @@ metadata:
     eventing.knative.dev/broker.class: RabbitMQBroker
 spec:
   config:
-    apiVersion: rabbitmq.com/v1beta1
-    kind: RabbitmqCluster
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: RabbitmqBrokerConfig
+    name: rabbitmq-broker-config
+---
+
+apiVersion: eventing.knative.dev/v1alpha1
+kind: RabbitmqBrokerConfig
+metadata:
+  name: rabbitmq-broker-config
+  namespace: {{ .namespace }}
+spec:
+  rabbitmqClusterReference:
     name: rabbitmqc
+    namespace: {{ .namespace }}

--- a/test/e2e/config/smoke/brokertrigger/smoke.yaml
+++ b/test/e2e/config/smoke/brokertrigger/smoke.yaml
@@ -23,10 +23,9 @@ metadata:
     eventing.knative.dev/broker.class: RabbitMQBroker
 spec:
   config:
-    apiVersion: rabbitmq.com/v1beta1
-    kind: RabbitmqCluster
-    name: rabbitmqc
-
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: RabbitmqBrokerConfig
+    name: rabbitmq-broker-config
 ---
 
 apiVersion: eventing.knative.dev/v1
@@ -38,3 +37,15 @@ spec:
   broker: testbroker
   subscriber:
     uri: http://example.com
+
+---
+
+apiVersion: eventing.knative.dev/v1alpha1
+kind: RabbitmqBrokerConfig
+metadata:
+  name: rabbitmq-broker-config
+  namespace: {{ .namespace }}
+spec:
+  rabbitmqClusterReference:
+    name: rabbitmqc
+    namespace: {{ .namespace }}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -30,14 +30,11 @@ import (
 	"knative.dev/pkg/system"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
 	// For our e2e testing, we want this linked first so that our
 	// system namespace environment variable is defaulted prior to
 	// logstream initialization.
 	_ "knative.dev/eventing-rabbitmq/test/defaultsystem"
 	"knative.dev/reconciler-test/pkg/environment"
-	"knative.dev/reconciler-test/pkg/k8s"
-	"knative.dev/reconciler-test/pkg/knative"
 )
 
 func init() {

--- a/test/e2e/smoke_test_broker_trigger.go
+++ b/test/e2e/smoke_test_broker_trigger.go
@@ -46,9 +46,10 @@ func SmokeTestBrokerTrigger() *feature.Feature {
 func AllGoReady(ctx context.Context, t feature.T) {
 	env := environment.FromContext(ctx)
 	for _, ref := range env.References() {
-		if !strings.Contains(ref.APIVersion, "knative.dev") {
+		if !strings.Contains(ref.APIVersion, "knative.dev") || ref.Kind == "RabbitmqBrokerConfig" {
 			// Let's not care so much about checking the status of non-Knative
 			// resources.
+			// RabbitmqBrokerConfig isn't a reconciled resources, so won't have any Status
 			continue
 		}
 		if err := k8s.WaitForReadyOrDone(ctx, t, ref, interval, timeout); err != nil {


### PR DESCRIPTION
- 🧹  Update conformance and e2e tests to use RabbitmqBrokerConfig
- 🧹 temporarily remove queueType from broker config.

/kind cleanup

