### PR TITLE
Deprecate the use of RabbitMQCluster as a broker config. Document usage of new broker config

### DIFF
--- a/samples/broker-trigger/quick-setup/250-broker-config.yaml
+++ b/samples/broker-trigger/quick-setup/250-broker-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: eventing.knative.dev/v1alpha1
+kind: RabbitmqBrokerConfig
+metadata:
+  name: default-config
+  namespace: broker-trigger-demo
+spec:
+  rabbitmqClusterReference:
+    name: rabbitmq
+    namespace: broker-trigger-demo

--- a/samples/broker-trigger/quick-setup/300-broker.yaml
+++ b/samples/broker-trigger/quick-setup/300-broker.yaml
@@ -7,9 +7,9 @@ metadata:
     eventing.knative.dev/broker.class: RabbitMQBroker
 spec:
   config:
-    apiVersion: rabbitmq.com/v1beta1
-    kind: RabbitmqCluster
-    name: rabbitmq
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: RabbitmqBrokerConfig
+    name: default-config
   delivery:
     deadLetterSink:
       ref:

--- a/samples/broker-trigger/quick-setup/README.md
+++ b/samples/broker-trigger/quick-setup/README.md
@@ -74,12 +74,61 @@ spec:
 EOF
 ```
 
+### Create the RabbitMQ Broker Config
+
+```sh
+kubectl apply -f samples/broker-trigger/quick-setup/250-broker-config.yaml
+```
+or
+```sh
+kubectl apply -f - << EOF
+apiVersion: eventing.knative.dev/v1alpha1
+kind: RabbitmqBrokerConfig
+metadata:
+  name: default-config
+  namespace: broker-trigger-demo
+spec:
+  rabbitmqClusterReference:
+    name: rabbitmq
+    namespace: broker-trigger-demo
+
+```
+
 ### Create the RabbitMQ Broker
 
 ```sh
 kubectl apply -f samples/broker-trigger/quick-setup/300-broker.yaml
 ```
 or
+```sh
+kubectl apply -f - << EOF
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: default
+  namespace: broker-trigger-demo
+  annotations:
+    eventing.knative.dev/broker.class: RabbitMQBroker
+spec:
+  config:
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: RabbitmqBrokerConfig
+    name: default-config
+  delivery:
+    deadLetterSink:
+      ref:
+        apiVersion: serving.knative.dev/v1
+        kind: Service
+        name: event-display
+        namespace: broker-trigger-demo
+    retry: 5
+EOF
+```
+
+### [DEPRECATED] Create the RabbitMQ Broker (with RabbitmqCluster as config)
+
+While using a reference to a RabbitmqCluster directly is supported, it's deprecated and will be removed in a future release
+
 ```sh
 kubectl apply -f - << EOF
 apiVersion: eventing.knative.dev/v1

--- a/samples/broker-trigger/tracing/broker-config.yaml
+++ b/samples/broker-trigger/tracing/broker-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: eventing.knative.dev/v1alpha1
+kind: RabbitmqBrokerConfig
+metadata:
+  name: default-config
+  namespace: rmqbroker
+spec:
+  rabbitmqClusterReference:
+    name: cluster
+    namespace: rmqbroker

--- a/samples/broker-trigger/tracing/broker.yaml
+++ b/samples/broker-trigger/tracing/broker.yaml
@@ -7,7 +7,6 @@ metadata:
     eventing.knative.dev/broker.class: RabbitMQBroker
 spec:
   config:
-    apiVersion: rabbitmq.com/v1beta1
-    kind: RabbitmqCluster
-    name: cluster
-    namespace: rmqbroker
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: RabbitmqBrokerConfig
+    name: default-config

--- a/samples/broker-trigger/trigger-customizations/250-broker-config.yaml
+++ b/samples/broker-trigger/trigger-customizations/250-broker-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: eventing.knative.dev/v1alpha1
+kind: RabbitmqBrokerConfig
+metadata:
+  name: default-config
+  namespace: trigger-demo
+spec:
+  rabbitmqClusterReference:
+    name: rabbitmq
+    namespace: trigger-demo

--- a/samples/broker-trigger/trigger-customizations/300-broker.yaml
+++ b/samples/broker-trigger/trigger-customizations/300-broker.yaml
@@ -7,6 +7,6 @@ metadata:
     eventing.knative.dev/broker.class: RabbitMQBroker
 spec:
   config:
-    apiVersion: rabbitmq.com/v1beta1
-    kind: RabbitmqCluster
-    name: rabbitmq
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: RabbitmqBrokerConfig
+    name: default-config

--- a/samples/broker-trigger/trigger-customizations/README.md
+++ b/samples/broker-trigger/trigger-customizations/README.md
@@ -58,6 +58,26 @@ spec:
 EOF
 ```
 
+### Create the RabbitMQ Broker Config
+
+```sh
+kubectl apply -f samples/broker-trigger/trigger-customizations/250-broker-config.yaml
+```
+or
+```sh
+kubectl apply -f - << EOF
+apiVersion: eventing.knative.dev/v1alpha1
+kind: RabbitmqBrokerConfig
+metadata:
+  name: default-config
+  namespace: trigger-demo
+spec:
+  rabbitmqClusterReference:
+    name: rabbitmq
+    namespace: trigger-demo
+
+```
+
 #### Create a Broker
 ```sh
 kubectl apply -f samples/broker-trigger/trigger-customizations/300-broker.yaml
@@ -74,9 +94,9 @@ metadata:
     eventing.knative.dev/broker.class: RabbitMQBroker
 spec:
   config:
-    apiVersion: rabbitmq.com/v1beta1
-    kind: RabbitmqCluster
-    name: rabbitmq
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: RabbitmqBrokerConfig
+    name: default-config
 EOF
 ```
 


### PR DESCRIPTION
- 🧹  Adds docs on how to use RabbitmqBrokerConfig. 
- 🧹  Adds Deprecated notice to old RabbitmqCluster reference


/kind documentation
/kind cleanup

