### PR TITLE
Configurable queue type

### DIFF
--- a/config/broker/300-rabbitmqbrokerconfig.yaml
+++ b/config/broker/300-rabbitmqbrokerconfig.yaml
@@ -41,6 +41,12 @@ spec:
             type: object
           spec:
             properties:
+              queueType:
+                default: quorum
+                enum:
+                - quorum
+                - classic
+                type: string
               rabbitmqClusterReference:
                 description: RabbitmqClusterReference stores a reference to RabbitmqCluster.
                   This will get used to create resources on the RabbitMQ Broker.

--- a/pkg/apis/eventing/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/eventing/v1alpha1/rabbitmq_types.go
@@ -44,6 +44,13 @@ var _ resourcesemantics.GenericCRD = (*RabbitmqBrokerConfig)(nil)
 var _ apis.Defaultable = (*RabbitmqBrokerConfig)(nil)
 var _ apis.Validatable = (*RabbitmqBrokerConfig)(nil)
 
+type QueueType string
+
+var (
+	QuorumQueueType  = QueueType("quorum")
+	ClassicQueueType = QueueType("classic")
+)
+
 type RabbitmqBrokerConfigSpec struct {
 	// RabbitmqClusterReference stores a reference to RabbitmqCluster. This will get used to create resources on the RabbitMQ Broker.
 	RabbitmqClusterReference *v1beta1.RabbitmqClusterReference `json:"rabbitmqClusterReference,omitempty"`
@@ -51,7 +58,7 @@ type RabbitmqBrokerConfigSpec struct {
 	// +optional
 	// +kubebuilder:default:=quorum
 	// +kubebuilder:validation:Enum=quorum;classic
-	QueueType string `json:"queueType,omitempty"`
+	QueueType QueueType `json:"queueType"`
 }
 
 func (s *RabbitmqBrokerConfig) GetGroupVersionKind() schema.GroupVersionKind {

--- a/pkg/apis/eventing/v1alpha1/rabbitmq_types.go
+++ b/pkg/apis/eventing/v1alpha1/rabbitmq_types.go
@@ -47,6 +47,11 @@ var _ apis.Validatable = (*RabbitmqBrokerConfig)(nil)
 type RabbitmqBrokerConfigSpec struct {
 	// RabbitmqClusterReference stores a reference to RabbitmqCluster. This will get used to create resources on the RabbitMQ Broker.
 	RabbitmqClusterReference *v1beta1.RabbitmqClusterReference `json:"rabbitmqClusterReference,omitempty"`
+
+	// +optional
+	// +kubebuilder:default:=quorum
+	// +kubebuilder:validation:Enum=quorum;classic
+	QueueType string `json:"queueType,omitempty"`
 }
 
 func (s *RabbitmqBrokerConfig) GetGroupVersionKind() schema.GroupVersionKind {

--- a/pkg/apis/eventing/v1alpha1/rabbitmq_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/rabbitmq_validation_test.go
@@ -28,6 +28,7 @@ import (
 func TestValidateRabbitmqBrokerConfig(t *testing.T) {
 	validBrokerConfig := &RabbitmqBrokerConfig{
 		Spec: RabbitmqBrokerConfigSpec{
+			QueueType: "quorum",
 			RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{
 				Namespace: "some-namespace",
 				Name:      "some-name",
@@ -59,7 +60,9 @@ func TestValidateRabbitmqBrokerConfig(t *testing.T) {
 		},
 		"missing rabbitmqClusterReference": {
 			newConfig: &RabbitmqBrokerConfig{
-				Spec: RabbitmqBrokerConfigSpec{},
+				Spec: RabbitmqBrokerConfigSpec{
+					QueueType: "classic",
+				},
 			},
 			wantErr:  true,
 			isUpdate: false,

--- a/pkg/rabbit/queue.go
+++ b/pkg/rabbit/queue.go
@@ -24,6 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	eventingv1alpha1 "knative.dev/eventing-rabbitmq/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 	rabbitv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 )
@@ -38,6 +39,7 @@ type QueueArgs struct {
 	DLXName                  *string
 	Source                   *v1alpha1.RabbitmqSource
 	BrokerUID                string
+	QueueType                eventingv1alpha1.QueueType
 }
 
 func NewQueue(args *QueueArgs) *rabbitv1beta1.Queue {
@@ -46,10 +48,14 @@ func NewQueue(args *QueueArgs) *rabbitv1beta1.Queue {
 	autoDelete := false
 	queueName := args.Name
 	vhost := "/"
+	queueType := eventingv1alpha1.QuorumQueueType
 	if args.QueueName != "" {
 		queueName = args.QueueName
 	}
 
+	if args.QueueType != "" {
+		queueType = args.QueueType
+	}
 	// queue configurations for source
 	if args.Source != nil {
 		durable = args.Source.Spec.QueueConfig.Durable
@@ -71,6 +77,7 @@ func NewQueue(args *QueueArgs) *rabbitv1beta1.Queue {
 			Durable:                  durable,
 			AutoDelete:               autoDelete,
 			RabbitmqClusterReference: *args.RabbitmqClusterReference,
+			Type:                     string(queueType),
 		},
 	}
 }

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -297,12 +297,17 @@ func (r *Reconciler) reconcileDeadLetterResources(ctx context.Context, b *eventi
 	if err != nil {
 		return err, false
 	}
+	queueType, err := r.brokerConfig.GetQueueType(ctx, b)
+	if err != nil {
+		return err, false
+	}
 	queue, err := r.rabbit.ReconcileQueue(ctx, &rabbit.QueueArgs{
 		Name:                     naming.CreateBrokerDeadLetterQueueName(b),
 		Namespace:                b.Namespace,
 		RabbitmqClusterReference: clusterRef,
 		Owner:                    *kmeta.NewControllerRef(b),
 		Labels:                   rabbit.Labels(b, nil, nil),
+		QueueType:                queueType,
 	})
 	if err != nil {
 		MarkDLXFailed(&b.Status, "QueueFailure", fmt.Sprintf("Failed to reconcile Dead Letter Queue %q : %s", naming.CreateBrokerDeadLetterQueueName(b), err))

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -133,6 +133,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *eventingv1.Trigger) p
 	if err != nil {
 		return err
 	}
+	queueType, err := r.brokerConfig.GetQueueType(ctx, broker)
+	if err != nil {
+		return err
+	}
 	if t.Spec.Delivery != nil && t.Spec.Delivery.DeadLetterSink != nil {
 		// If there's DeadLetterSink, we need to create a DLX that's specific for this Trigger as well
 		// as a Queue for it, and Dispatcher that pulls from that queue.
@@ -161,6 +165,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *eventingv1.Trigger) p
 			RabbitmqClusterReference: ref,
 			Owner:                    *kmeta.NewControllerRef(t),
 			Labels:                   rabbit.Labels(broker, t, nil),
+			QueueType:                queueType,
 		})
 		if err != nil {
 			logging.FromContext(ctx).Error("Problem reconciling Trigger Queue", zap.Error(err))
@@ -210,6 +215,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *eventingv1.Trigger) p
 		Owner:                    *kmeta.NewControllerRef(t),
 		Labels:                   rabbit.Labels(broker, t, nil),
 		DLXName:                  dlxName,
+		QueueType:                queueType,
 	})
 	if err != nil {
 		logging.FromContext(ctx).Error("Problem reconciling Trigger Queue", zap.Error(err))

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -252,7 +252,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithFilter(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(true)),
 				},
 				WantCreates: []runtime.Object{
@@ -269,7 +269,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithFilter(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(true)),
 				},
 				WantCreates: []runtime.Object{
@@ -287,7 +287,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithDeliverySpec(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(true)),
 				},
 				WantCreates: []runtime.Object{
@@ -307,7 +307,7 @@ func TestReconcile(t *testing.T) {
 					createRabbitMQBrokerConfig(),
 				},
 				WantCreates: []runtime.Object{
-					createQueue(),
+					createQueue(config),
 				},
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 					Object: triggerWithQueueNotReady(),
@@ -329,7 +329,7 @@ func TestReconcile(t *testing.T) {
 					Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create queues"),
 				},
 				WantCreates: []runtime.Object{
-					createQueue(),
+					createQueue(config),
 				},
 				WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 					Object: triggerWithQueueCreateFailure(),
@@ -342,7 +342,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithFilter(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 				},
 				WantCreates: []runtime.Object{
 					createBinding(true),
@@ -358,7 +358,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithFilter(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 				},
 				WithReactors: []clientgotesting.ReactionFunc{
 					InduceFailure("create", "bindings"),
@@ -381,7 +381,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithFilter(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(true)),
 				},
 				WantCreates: []runtime.Object{
@@ -396,7 +396,7 @@ func TestReconcile(t *testing.T) {
 				Objects: []runtime.Object{
 					ReadyBroker(config),
 					makeSubscriberAddressableAsUnstructured(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 					NewTrigger(triggerName, testNS, brokerName,
 						WithTriggerUID(triggerUID),
@@ -424,7 +424,7 @@ func TestReconcile(t *testing.T) {
 				Objects: []runtime.Object{
 					ReadyBroker(config),
 					makeSubscriberNotAddressableAsUnstructured(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 					NewTrigger(triggerName, testNS, brokerName,
 						WithTriggerUID(triggerUID),
@@ -456,7 +456,7 @@ func TestReconcile(t *testing.T) {
 						WithTriggerSubscriberURI(subscriberURI)),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 				},
 				WithReactors: []clientgotesting.ReactionFunc{
@@ -492,7 +492,7 @@ func TestReconcile(t *testing.T) {
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
 					createDifferentDispatcherDeployment(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 				},
 				WithReactors: []clientgotesting.ReactionFunc{
@@ -527,7 +527,7 @@ func TestReconcile(t *testing.T) {
 						WithTriggerSubscriberURI(subscriberURI)),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 					createDispatcherDeployment(),
 				},
@@ -551,7 +551,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithFilter(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(true)),
 					createDispatcherDeployment(),
 				},
@@ -569,7 +569,7 @@ func TestReconcile(t *testing.T) {
 						WithInitTriggerConditions,
 						WithDependencyAnnotation(dependencyAnnotation),
 					),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 				},
 				WantEvents: []string{
@@ -601,7 +601,7 @@ func TestReconcile(t *testing.T) {
 					),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 				},
 				WantErr: false,
@@ -630,7 +630,7 @@ func TestReconcile(t *testing.T) {
 					),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 				},
 				WantErr: false,
@@ -659,7 +659,7 @@ func TestReconcile(t *testing.T) {
 					),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 				},
 				WantErr: false,
@@ -686,7 +686,7 @@ func TestReconcile(t *testing.T) {
 					),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 				},
 				WantErr: true,
@@ -717,7 +717,7 @@ func TestReconcile(t *testing.T) {
 					),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 				},
 				WantErr: false,
@@ -749,7 +749,7 @@ func TestReconcile(t *testing.T) {
 						WithTriggerSubscriberURI(subscriberURI)),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
-					markReady(createQueue()),
+					markReady(createQueue(config)),
 					markReady(createBinding(false)),
 					createDispatcherDeploymentWithParallelism(),
 				},
@@ -1159,7 +1159,11 @@ func makeSubscriberNotAddressableAsUnstructured() *unstructured.Unstructured {
 	}
 }
 
-func createQueue() *rabbitv1beta1.Queue {
+func createQueue(kref *duckv1.KReference) *rabbitv1beta1.Queue {
+	queueType := v1alpha1.ClassicQueueType
+	if kref.Kind == "RabbitmqBrokerConfig" {
+		queueType = v1alpha1.QuorumQueueType
+	}
 	labels := map[string]string{
 		"eventing.knative.dev/broker":  brokerName,
 		"eventing.knative.dev/trigger": triggerName,
@@ -1182,6 +1186,7 @@ func createQueue() *rabbitv1beta1.Queue {
 				Name:      rabbitMQBrokerName,
 				Namespace: testNS,
 			},
+			Type: string(queueType),
 		},
 	}
 }


### PR DESCRIPTION
Changes:
- queueType configurable when using RabbitmqBrokerConfig
- queueType will default to classic queue when RabbitmqCluster is used as a config
- queueType will default to quorum for all other scenarios

Note: This is a breaking change for rabbitmqSource as the queueType will be changing from classic to quorum.

/kind enhancement

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
QueueType is configurable (quorum and classic) if using RabbitmqBrokerConfig
```


/hold for tests