### PR TITLE
Make sure rabbitmq set up properly and test env allows reproducibility

### DIFF
--- a/samples/broker-trigger/quick-setup/200-rabbitmq.yaml
+++ b/samples/broker-trigger/quick-setup/200-rabbitmq.yaml
@@ -6,3 +6,13 @@ metadata:
   namespace: broker-trigger-demo
 spec:
   replicas: 1
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              env:
+              - name: ERL_MAX_PORTS
+                value: "4096"

--- a/samples/broker-trigger/quick-setup/README.md
+++ b/samples/broker-trigger/quick-setup/README.md
@@ -71,8 +71,20 @@ metadata:
   namespace: broker-trigger-demo
 spec:
   replicas: 1
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              env:
+              - name: ERL_MAX_PORTS
+                value: "4096"
 EOF
 ```
+
+_NOTE_: here we set ERL_MAX_PORTS to prevent unnecessary memory allocation by RabbitMQ and potential memory limit problems. [Read more here](https://github.com/rabbitmq/cluster-operator/issues/959)
 
 ### Create the RabbitMQ Broker Config
 

--- a/samples/broker-trigger/tracing/400-cluster.yaml
+++ b/samples/broker-trigger/tracing/400-cluster.yaml
@@ -5,3 +5,13 @@ metadata:
   namespace: rmqbroker
 spec:
   replicas: 1
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              env:
+              - name: ERL_MAX_PORTS
+                value: "4096"

--- a/samples/broker-trigger/trigger-customizations/200-rabbitmq.yaml
+++ b/samples/broker-trigger/trigger-customizations/200-rabbitmq.yaml
@@ -6,3 +6,13 @@ metadata:
   namespace: trigger-demo
 spec:
   replicas: 1
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              env:
+              - name: ERL_MAX_PORTS
+                value: "4096"

--- a/samples/broker-trigger/trigger-customizations/README.md
+++ b/samples/broker-trigger/trigger-customizations/README.md
@@ -55,8 +55,21 @@ metadata:
   namespace: trigger-demo
 spec:
   replicas: 1
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              env:
+              - name: ERL_MAX_PORTS
+                value: "4096"
 EOF
 ```
+
+_NOTE_: here we set ERL_MAX_PORTS to prevent unnecessary memory allocation by RabbitMQ and potential memory limit problems. [Read more here](https://github.com/rabbitmq/cluster-operator/issues/959)
+
 
 ### Create the RabbitMQ Broker Config
 

--- a/samples/multiple-namespaces/200-rabbitmq-cluster.yaml
+++ b/samples/multiple-namespaces/200-rabbitmq-cluster.yaml
@@ -13,3 +13,13 @@ metadata:
     rabbitmq.com/topology-allowed-namespaces: "*"
 spec:
   replicas: 1
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              env:
+              - name: ERL_MAX_PORTS
+                value: "4096"

--- a/samples/source/external-cluster/resources/rabbitmq-sample-deployment.yaml
+++ b/samples/source/external-cluster/resources/rabbitmq-sample-deployment.yaml
@@ -29,6 +29,9 @@ spec:
   containers:
   - image: rabbitmq:3-management
     name: rabbitmq
+    env:
+    - name: ERL_MAX_PORTS
+      value: "4096"
     ports:
     - containerPort: 15672
     - containerPort: 5672

--- a/samples/source/quick-setup/200-rabbitmq.yaml
+++ b/samples/source/quick-setup/200-rabbitmq.yaml
@@ -6,3 +6,13 @@ metadata:
   namespace: source-demo
 spec:
   replicas: 1
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              env:
+              - name: ERL_MAX_PORTS
+                value: "4096"

--- a/test/conformance/resources/rabbitmqcluster/rabbitmqcluster.yaml
+++ b/test/conformance/resources/rabbitmqcluster/rabbitmqcluster.yaml
@@ -12,3 +12,13 @@ spec:
     requests:
       cpu: "100m"
       memory: "1Gi"
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              env:
+              - name: ERL_MAX_PORTS
+                value: "4096"

--- a/test/e2e/config/rabbitmq/cluster.yaml
+++ b/test/e2e/config/rabbitmq/cluster.yaml
@@ -30,3 +30,13 @@ spec:
     requests:
       cpu: "400m"
       memory: "600Mi"
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              env:
+              - name: ERL_MAX_PORTS
+                value: "4096"

--- a/test/e2e/config/rabbitmqvhost/clustervhost.yaml
+++ b/test/e2e/config/rabbitmqvhost/clustervhost.yaml
@@ -26,6 +26,16 @@ spec:
     requests:
       cpu: "400m"
       memory: "600Mi"
+  override:
+    statefulSet:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: rabbitmq
+              env:
+              - name: ERL_MAX_PORTS
+                value: "4096"
   rabbitmq:
     additionalConfig: |
       default_vhost = test-vhost


### PR DESCRIPTION
See https://github.com/rabbitmq/cluster-operator/issues/959

Unfortunately docker doesn't give enough isolation/reproducability and kernel's fs.max-fds makes into containers. Which means our tests/samples can't run on arbitrary systems - i.e. test env not sealed. Please take a look inside linked operator issue.

**TODO:** Let's decide what are the good values for samples and performance cluster.

cc @coro

# Changes

- :bug: Limit ERL_MAX_PORTS explicitly, since host's fs.fd-max leaks into containers. 

/kind bug

**Release Note**


```release-note
Limit ERL_MAX_PORTS explicitly in tests, since host's fs.fd-max leaks into containers. the values provided in samples might be too concervative, please adjust to the taste. 
```

