### PR TITLE
Adds metrics to dispatcher pods

### DIFF
--- a/cmd/dispatcher/main.go
+++ b/cmd/dispatcher/main.go
@@ -25,9 +25,12 @@ import (
 
 	"github.com/NeowayLabs/wabbit"
 	"github.com/NeowayLabs/wabbit/amqp"
+	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
 	amqperr "github.com/rabbitmq/amqp091-go"
+	"knative.dev/pkg/kmeta"
 
+	dispatcherstats "knative.dev/eventing-rabbitmq/pkg/broker/dispatcher"
 	"knative.dev/eventing-rabbitmq/pkg/dispatcher"
 	"knative.dev/eventing-rabbitmq/pkg/utils"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
@@ -51,6 +54,11 @@ type envConfig struct {
 	BackoffDelay  time.Duration `envconfig:"BACKOFF_DELAY" default:"50ms" required:"false"`
 	Timeout       time.Duration `envconfig:"TIMEOUT" default:"0s" required:"false"`
 
+	ContainerName string `envconfig:"CONTAINER_NAME"`
+	PodName       string `envconfig:"POD_NAME"`
+	Namespace     string `envconfig:"NAMESPACE"`
+
+	reporter   dispatcherstats.StatsReporter
 	connection *amqp.Conn
 	channel    wabbit.Channel
 }
@@ -97,6 +105,7 @@ func main() {
 		}
 	}()
 
+	reporter := dispatcherstats.NewStatsReporter(env.ContainerName, kmeta.ChildName(env.PodName, uuid.New().String()), env.Namespace)
 	d := &dispatcher.Dispatcher{
 		BrokerIngressURL: env.BrokerIngressURL,
 		SubscriberURL:    env.SubscriberURL,
@@ -105,6 +114,7 @@ func main() {
 		Timeout:          env.Timeout,
 		BackoffPolicy:    backoffPolicy,
 		WorkerCount:      env.Parallelism,
+		Reporter:         reporter,
 	}
 
 	for {

--- a/cmd/dispatcher/main.go
+++ b/cmd/dispatcher/main.go
@@ -58,7 +58,6 @@ type envConfig struct {
 	PodName       string `envconfig:"POD_NAME"`
 	Namespace     string `envconfig:"NAMESPACE"`
 
-	reporter   dispatcherstats.StatsReporter
 	connection *amqp.Conn
 	channel    wabbit.Channel
 }

--- a/pkg/broker/dispatcher/stats_exporter_test.go
+++ b/pkg/broker/dispatcher/stats_exporter_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dispatcher
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"knative.dev/eventing/pkg/broker"
+	"knative.dev/eventing/pkg/metrics"
+	"knative.dev/pkg/metrics/metricstest"
+	_ "knative.dev/pkg/metrics/testing"
+)
+
+func TestStatsReporter(t *testing.T) {
+	setup()
+
+	args := &ReportArgs{
+		EventType: "testeventtype",
+	}
+
+	r := NewStatsReporter("testcontainer", "testpod", "testns")
+
+	wantTags := map[string]string{
+		metrics.LabelEventType:         "testeventtype",
+		metrics.LabelResponseCode:      "202",
+		metrics.LabelResponseCodeClass: "2xx",
+		broker.LabelUniqueName:         "testpod",
+		broker.LabelContainerName:      "testcontainer",
+	}
+
+	// test ReportEventCount
+	expectSuccess(t, func() error {
+		return r.ReportEventCount(args, http.StatusAccepted)
+	})
+	expectSuccess(t, func() error {
+		return r.ReportEventCount(args, http.StatusAccepted)
+	})
+	metricstest.AssertMetric(t, metricstest.IntMetric("event_count", 2, wantTags))
+
+	// test ReportDispatchTime
+	expectSuccess(t, func() error {
+		return r.ReportEventDispatchTime(args, http.StatusAccepted, 1100*time.Millisecond)
+	})
+	expectSuccess(t, func() error {
+		return r.ReportEventDispatchTime(args, http.StatusAccepted, 9100*time.Millisecond)
+	})
+	metricstest.AssertMetric(t, metricstest.DistributionCountOnlyMetric("event_dispatch_latencies", 2, wantTags))
+	metricstest.CheckDistributionData(t, "event_dispatch_latencies", wantTags, 2, 1100.0, 9100.0)
+}
+
+func expectSuccess(t *testing.T, f func() error) {
+	t.Helper()
+	if err := f(); err != nil {
+		t.Error("Reporter expected success but got error:", err)
+	}
+}
+
+func setup() {
+	resetMetrics()
+}
+
+func resetMetrics() {
+	// OpenCensus metrics carry global state that need to be reset between unit tests.
+	metricstest.Unregister(
+		"event_count",
+		"event_dispatch_latencies")
+	register()
+}

--- a/pkg/reconciler/broker/resources/dispatcher.go
+++ b/pkg/reconciler/broker/resources/dispatcher.go
@@ -88,6 +88,15 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 	}, {
 		Name:  "BROKER_INGRESS_URL",
 		Value: args.BrokerIngressURL.String(),
+	}, {
+		Name:  "NAMESPACE",
+		Value: args.Broker.Namespace,
+	}, {
+		Name:  "CONTAINER_NAME",
+		Value: dispatcherContainerName,
+	}, {
+		Name:  "POD_NAME",
+		Value: DispatcherName(args.Broker.Name),
 	}}
 	if args.Configs != nil {
 		envs = append(envs, args.Configs.ToEnvVars()...)
@@ -157,6 +166,10 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 								corev1.ResourceCPU:    resource.MustParse("4000m"),
 								corev1.ResourceMemory: resource.MustParse("600Mi")},
 						},
+						Ports: []corev1.ContainerPort{{
+							Name:          "http-metrics",
+							ContainerPort: 9090,
+						}},
 					}},
 				},
 			},

--- a/pkg/reconciler/broker/resources/dispatcher_test.go
+++ b/pkg/reconciler/broker/resources/dispatcher_test.go
@@ -140,6 +140,15 @@ func TestMakeDispatcherDeployment(t *testing.T) {
 							Name:  "BROKER_INGRESS_URL",
 							Value: brokerIngressURL,
 						}, {
+							Name:  "NAMESPACE",
+							Value: args.Broker.Namespace,
+						}, {
+							Name:  "CONTAINER_NAME",
+							Value: dispatcherContainerName,
+						}, {
+							Name:  "POD_NAME",
+							Value: DispatcherName(args.Broker.Name),
+						}, {
 							Name:  "RETRY",
 							Value: "10",
 						}, {
@@ -148,6 +157,10 @@ func TestMakeDispatcherDeployment(t *testing.T) {
 						}, {
 							Name:  "BACKOFF_DELAY",
 							Value: "20s",
+						}},
+						Ports: []corev1.ContainerPort{{
+							Name:          "http-metrics",
+							ContainerPort: 9090,
 						}},
 					}},
 				},

--- a/pkg/reconciler/trigger/resources/dispatcher.go
+++ b/pkg/reconciler/trigger/resources/dispatcher.go
@@ -91,6 +91,15 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 		}, {
 			Name:  "BROKER_INGRESS_URL",
 			Value: args.BrokerIngressURL.String(),
+		}, {
+			Name:  "NAMESPACE",
+			Value: args.Trigger.Namespace,
+		}, {
+			Name:  "CONTAINER_NAME",
+			Value: dispatcherContainerName,
+		}, {
+			Name:  "POD_NAME",
+			Value: name,
 		}},
 		// This resource requests and limits comes from performance testing 1500msgs/s with a parallelism of 1000
 		// more info in this issue: https://github.com/knative-sandbox/eventing-rabbitmq/issues/703
@@ -102,6 +111,10 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 				corev1.ResourceCPU:    resource.MustParse("4000m"),
 				corev1.ResourceMemory: resource.MustParse("600Mi")},
 		},
+		Ports: []corev1.ContainerPort{{
+			Name:          "http-metrics",
+			ContainerPort: 9090,
+		}},
 	}
 	if args.Configs != nil {
 		dispatcher.Env = append(dispatcher.Env, args.Configs.ToEnvVars()...)


### PR DESCRIPTION
- Adds metrics similar to [eventing-core](https://knative.dev/docs/eventing/observability/metrics/eventing-metrics/#in-memory-dispatcher) to both Trigger and Broker (dlq) dispatcher pods

/kind enhancement

Fixes #415 

**Release Note**

```release-note
Added metrics to dispatcher pods
```
