### PR TITLE
Attempts to remove any leftover DLQ resources that are no longer needed

### DIFF
--- a/pkg/rabbit/types.go
+++ b/pkg/rabbit/types.go
@@ -35,4 +35,5 @@ type Service interface {
 	ReconcileBinding(context.Context, *BindingArgs) (Result, error)
 	ReconcileBrokerDLXPolicy(context.Context, *QueueArgs) (Result, error)
 	ReconcileDLQPolicy(context.Context, *QueueArgs) (Result, error)
+	DeleteResource(ctx context.Context, args *DeleteResourceArgs) error
 }

--- a/pkg/reconciler/trigger/resources/dispatcher.go
+++ b/pkg/reconciler/trigger/resources/dispatcher.go
@@ -60,12 +60,8 @@ type DispatcherArgs struct {
 // MakeDispatcherDeployment creates the in-memory representation of the Broker's Dispatcher Deployment.
 func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 	one := int32(1)
-	var name string
-	if args.DLX {
-		name = fmt.Sprintf("%s-dlx-dispatcher", args.Trigger.Name)
-	} else {
-		name = fmt.Sprintf("%s-dispatcher", args.Trigger.Name)
-	}
+	name := DispatcherName(args.Trigger.Name, args.DLX)
+
 	dispatcher := corev1.Container{
 		Name:  dispatcherContainerName,
 		Image: args.Image,
@@ -204,5 +200,13 @@ func DispatcherLabels(brokerName string) map[string]string {
 	return map[string]string{
 		eventing.BrokerLabelKey:           brokerName,
 		"eventing.knative.dev/brokerRole": "dispatcher",
+	}
+}
+
+func DispatcherName(triggerName string, dlq bool) string {
+	if dlq {
+		return fmt.Sprintf("%s-dlx-dispatcher", triggerName)
+	} else {
+		return fmt.Sprintf("%s-dispatcher", triggerName)
 	}
 }


### PR DESCRIPTION
# Changes
- 🐛  Passively tries to remove any leftover resources. Will ignore errors as it won't affect functionality.

/kind bug

Fixes #465 

```release-note
- Removes leftover RMQ resources if a Trigger's delivery spec is removed
```

