### PR TITLE
Testing: e2e & conformance. Adds ability to specify custom images and secrets for rabbitmqclusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,20 +367,28 @@ test-e2e-publish: | $(KUBECONFIG) ## Run TestKoPublish end-to-end tests  - assum
 .PHONY: test-e2e-broker
 test-e2e-broker: | $(KUBECONFIG) ## Run Broker end-to-end tests - assumes a K8S with all necessary components installed (Knative & RabbitMQ)
 	@printf "$(WARN)$(BOLD)rabbitmqcluster$(NORMAL)$(WARN) has large resource requirements 🤔$(NORMAL)\n"
+	RABBITMQ_SERVER_IMAGE=$(RABBITMQ_SERVER_IMAGE) \
+	RABBITMQ_IMAGE_PULL_SECRET=$(RABBITMQ_IMAGE_PULL_SECRET) \
 	go test -v -race -count=1 -timeout=20m -tags=e2e ./test/e2e/... -run 'Test.*Broker.*'
 
 .PHONY: test-e2e-source
 test-e2e-source: | $(KUBECONFIG) ## Run Source end-to-end tests - assumes a K8S with all necessary components installed (Knative & RabbitMQ)
+	RABBITMQ_SERVER_IMAGE=$(RABBITMQ_SERVER_IMAGE) \
+	RABBITMQ_IMAGE_PULL_SECRET=$(RABBITMQ_IMAGE_PULL_SECRET) \
 	go test -v -race -count=1 -timeout=15m -tags=e2e ./test/e2e/... -run 'Test.*Source.*'
 
 .PHONY: test-e2e
 test-e2e: install ## Run all end-to-end tests - manages all dependencies, including K8S components
+	RABBITMQ_SERVER_IMAGE=$(RABBITMQ_SERVER_IMAGE) \
+	RABBITMQ_IMAGE_PULL_SECRET=$(RABBITMQ_IMAGE_PULL_SECRET) \
 	go test -v -race -count=1 -timeout=50m -tags=e2e ./test/e2e/...
 
 .PHONY: _test-conformance
 _test-conformance:
 	BROKER_TEMPLATES=$(BROKER_TEMPLATES) \
 	BROKER_CLASS=RabbitMQBroker \
+	RABBITMQ_SERVER_IMAGE=$(RABBITMQ_SERVER_IMAGE) \
+	RABBITMQ_IMAGE_PULL_SECRET=$(RABBITMQ_IMAGE_PULL_SECRET) \
 	go test -v -tags=e2e \
 		-count=1 -parallel=8 -timeout=1h \
 		-run TestBroker.*Conformance.* $(CURDIR)/test/conformance/...

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -29,6 +29,7 @@ import (
 	_ "knative.dev/pkg/system/testing"
 
 	"knative.dev/eventing-rabbitmq/test/conformance/features/rabbitmqcluster"
+	r "knative.dev/eventing-rabbitmq/test/conformance/resources/rabbitmqcluster"
 	"knative.dev/eventing/test/rekt/features/broker"
 	b "knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/reconciler-test/pkg/environment"
@@ -46,7 +47,7 @@ func TestBrokerControlPlaneConformance(t *testing.T) {
 		environment.Managed(t),
 	)
 
-	env.Prerequisite(ctx, t, rabbitmqcluster.GoesReady("rabbitbroker", b.WithEnvConfig()...))
+	env.Prerequisite(ctx, t, rabbitmqcluster.GoesReady("rabbitbroker", r.WithEnvConfig()...))
 	// Install and wait for a Ready Broker.
 	env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithEnvConfig()...))
 	env.TestSet(ctx, t, broker.ControlPlaneConformance("default"))
@@ -61,7 +62,7 @@ func TestBrokerDataPlaneConformance(t *testing.T) {
 		environment.Managed(t),
 	)
 
-	env.Prerequisite(ctx, t, rabbitmqcluster.GoesReady("rabbitbroker", b.WithEnvConfig()...))
+	env.Prerequisite(ctx, t, rabbitmqcluster.GoesReady("rabbitbroker", r.WithEnvConfig()...))
 	// Install and wait for a Ready Broker.
 	env.Prerequisite(ctx, t, broker.GoesReady("default3", b.WithEnvConfig()...))
 

--- a/test/conformance/resources/rabbitmqcluster/rabbitmqcluster.go
+++ b/test/conformance/resources/rabbitmqcluster/rabbitmqcluster.go
@@ -19,8 +19,10 @@ package rabbitmqcluster
 import (
 	"context"
 	"embed"
+	"log"
 	"time"
 
+	"github.com/kelseyhightower/envconfig"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
@@ -30,6 +32,46 @@ import (
 
 //go:embed "*.yaml"
 var yamls embed.FS
+
+var EnvCfg EnvConfig
+
+type EnvConfig struct {
+	RabbitmqServerImage     string `envconfig:"RABBITMQ_SERVER_IMAGE"`
+	RabbitmqImagePullSecret string `envconfig:"RABBITMQ_IMAGE_PULL_SECRET"`
+}
+
+func init() {
+	// Process EventingGlobal.
+	if err := envconfig.Process("", &EnvCfg); err != nil {
+		log.Fatal("Failed to process env var", err)
+	}
+}
+
+func WithEnvConfig() []manifest.CfgFn {
+	cfg := []manifest.CfgFn{}
+
+	if EnvCfg.RabbitmqServerImage != "" {
+		cfg = append(cfg, WithRabbitmqServerImage(EnvCfg.RabbitmqServerImage))
+	}
+
+	if EnvCfg.RabbitmqImagePullSecret != "" {
+		cfg = append(cfg, WithRabbitmqImagePullSecret(EnvCfg.RabbitmqImagePullSecret))
+	}
+
+	return cfg
+}
+
+func WithRabbitmqServerImage(name string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["rabbitmqServerImage"] = name
+	}
+}
+
+func WithRabbitmqImagePullSecret(name string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["rabbitmqImagePullSecretName"] = name
+	}
+}
 
 func GVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "rabbitmq.com", Version: "v1beta1", Resource: "rabbitmqclusters"}

--- a/test/conformance/resources/rabbitmqcluster/rabbitmqcluster.yaml
+++ b/test/conformance/resources/rabbitmqcluster/rabbitmqcluster.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ .name }}
   namespace: {{ .namespace }}
 spec:
+  {{ if .rabbitmqServerImage }}
+  image: {{ .rabbitmqServerImage }}
+  {{ end }}
+  {{ if .rabbitmqImagePullSecretName }}
+  imagePullSecrets:
+  - name: {{ .rabbitmqImagePullSecretName }}
+  {{ end }}
   replicas: 1
   resources:
     limits:

--- a/test/e2e/config/rabbitmq/cluster.yaml
+++ b/test/e2e/config/rabbitmq/cluster.yaml
@@ -22,6 +22,13 @@ metadata:
     # to declare objects against this RabbitMQ cluster
     rabbitmq.com/topology-allowed-namespaces: "*"
 spec:
+  {{ if .rabbitmqServerImage }}
+  image: {{ .rabbitmqServerImage }}
+  {{ end }}
+  {{ if .rabbitmqImagePullSecretName }}
+  imagePullSecrets:
+  - name: {{ .rabbitmqImagePullSecretName }}
+  {{ end }}
   replicas: 1
   resources:
     limits:

--- a/test/e2e/config/rabbitmq/rabbitmq.go
+++ b/test/e2e/config/rabbitmq/rabbitmq.go
@@ -19,7 +19,9 @@ package rabbitmq
 import (
 	"context"
 	"embed"
+	"log"
 
+	"github.com/kelseyhightower/envconfig"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
@@ -27,9 +29,54 @@ import (
 //go:embed "*.yaml"
 var yamls embed.FS
 
-func Install() feature.StepFn {
+var EnvCfg EnvConfig
+
+type EnvConfig struct {
+	RabbitmqServerImage     string `envconfig:"RABBITMQ_SERVER_IMAGE"`
+	RabbitmqImagePullSecret string `envconfig:"RABBITMQ_IMAGE_PULL_SECRET"`
+}
+
+func init() {
+	// Process EventingGlobal.
+	if err := envconfig.Process("", &EnvCfg); err != nil {
+		log.Fatal("Failed to process env var", err)
+	}
+}
+
+func WithEnvConfig() []manifest.CfgFn {
+	cfg := []manifest.CfgFn{}
+
+	if EnvCfg.RabbitmqServerImage != "" {
+		cfg = append(cfg, WithRabbitmqServerImage(EnvCfg.RabbitmqServerImage))
+	}
+
+	if EnvCfg.RabbitmqImagePullSecret != "" {
+		cfg = append(cfg, WithRabbitmqImagePullSecret(EnvCfg.RabbitmqImagePullSecret))
+	}
+
+	return cfg
+}
+
+func WithRabbitmqServerImage(name string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["rabbitmqServerImage"] = name
+	}
+}
+
+func WithRabbitmqImagePullSecret(name string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["rabbitmqImagePullSecretName"] = name
+	}
+}
+
+func Install(opts ...manifest.CfgFn) feature.StepFn {
+	cfg := map[string]interface{}{}
+	for _, fn := range opts {
+		fn(cfg)
+	}
+
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallYamlFS(ctx, yamls, nil); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yamls, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/e2e/config/rabbitmqvhost/rabbitmqvhost.go
+++ b/test/e2e/config/rabbitmqvhost/rabbitmqvhost.go
@@ -19,7 +19,9 @@ package rabbitmqvhost
 import (
 	"context"
 	"embed"
+	"log"
 
+	"github.com/kelseyhightower/envconfig"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
@@ -27,9 +29,54 @@ import (
 //go:embed "*.yaml"
 var yamls embed.FS
 
-func Install() feature.StepFn {
+var EnvCfg EnvConfig
+
+type EnvConfig struct {
+	RabbitmqServerImage     string `envconfig:"RABBITMQ_SERVER_IMAGE"`
+	RabbitmqImagePullSecret string `envconfig:"RABBITMQ_IMAGE_PULL_SECRET"`
+}
+
+func init() {
+	// Process EventingGlobal.
+	if err := envconfig.Process("", &EnvCfg); err != nil {
+		log.Fatal("Failed to process env var", err)
+	}
+}
+
+func WithEnvConfig() []manifest.CfgFn {
+	cfg := []manifest.CfgFn{}
+
+	if EnvCfg.RabbitmqServerImage != "" {
+		cfg = append(cfg, WithRabbitmqServerImage(EnvCfg.RabbitmqServerImage))
+	}
+
+	if EnvCfg.RabbitmqImagePullSecret != "" {
+		cfg = append(cfg, WithRabbitmqImagePullSecret(EnvCfg.RabbitmqImagePullSecret))
+	}
+
+	return cfg
+}
+
+func WithRabbitmqServerImage(name string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["rabbitmqServerImage"] = name
+	}
+}
+
+func WithRabbitmqImagePullSecret(name string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["rabbitmqImagePullSecretName"] = name
+	}
+}
+
+func Install(opts ...manifest.CfgFn) feature.StepFn {
+	cfg := map[string]interface{}{}
+	for _, fn := range opts {
+		fn(cfg)
+	}
+
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallYamlFS(ctx, yamls, nil); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yamls, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/e2e/rabbitmqcluster.go
+++ b/test/e2e/rabbitmqcluster.go
@@ -58,7 +58,7 @@ const (
 func RabbitMQCluster() *feature.Feature {
 	f := new(feature.Feature)
 
-	f.Setup("install a rabbitmqcluster", rabbitmq.Install())
+	f.Setup("install a rabbitmqcluster", rabbitmq.Install(rabbitmq.WithEnvConfig()...))
 	f.Requirement("RabbitMQCluster goes ready", RabbitMQClusterReady)
 	return f
 }
@@ -66,7 +66,7 @@ func RabbitMQCluster() *feature.Feature {
 func RabbitMQClusterVHost() *feature.Feature {
 	f := new(feature.Feature)
 
-	f.Setup("install a rabbitmqcluster with a default vhost and user permissions to it", rabbitmqvhost.Install())
+	f.Setup("install a rabbitmqcluster with a default vhost and user permissions to it", rabbitmqvhost.Install(rabbitmqvhost.WithEnvConfig()...))
 	f.Requirement("RabbitMQCluster goes ready", RabbitMQClusterReady)
 	f.Requirement("Add credentials to default user secret", RabbitMQClusterConnectionSecretVhost)
 	return f


### PR DESCRIPTION
Can specify `RABBITMQ_SERVER_IMAGE` and optionally `RABBITMQ_IMAGE_PULL_SECRET` if the image is in a private registry.