### PR TITLE
Adds support for eventing-rabbitmq->RMQ SSL communication with self-signed certs

### DIFF
--- a/pkg/rabbit/service.go
+++ b/pkg/rabbit/service.go
@@ -324,8 +324,7 @@ func (r *Rabbit) GetRabbitMQCASecret(ctx context.Context, clusterRef *rabbitv1be
 		if err != nil {
 			return "", err
 		}
-		secretName, _ := s.Data["caSecretName"]
-		return string(secretName), nil
+		return string(s.Data["caSecretName"]), nil
 	}
 
 	rabbitMQCluster, err := r.getClusterFromReference(ctx, clusterRef)

--- a/pkg/rabbit/service.go
+++ b/pkg/rabbit/service.go
@@ -283,33 +283,13 @@ func (r *Rabbit) RabbitMQURL(ctx context.Context, clusterRef *rabbitv1beta1.Rabb
 		return url.Parse(fmt.Sprintf("%s://%s:%s@%s:%s", protocol, username, password, splittedUri[0], port))
 	}
 
-	// TODO: make this better.
-	ref := &duckv1.KReference{
-		Kind:       "RabbitmqCluster",
-		APIVersion: "rabbitmq.com/v1beta1",
-		Name:       clusterRef.Name,
-		Namespace:  clusterRef.Namespace,
-	}
-	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	rab, err := r.getClusterFromReference(ctx, clusterRef)
 	if err != nil {
 		return nil, err
 	}
 
-	gvk := gv.WithKind(ref.Kind)
-	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
-	_, lister, err := r.rabbitLister.Get(ctx, gvr)
-	if err != nil {
-		return nil, err
-	}
-
-	o, err := lister.ByNamespace(ref.Namespace).Get(ref.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	rab := o.(*duckv1beta1.Rabbit)
 	if rab.Status.DefaultUser == nil || rab.Status.DefaultUser.SecretReference == nil || rab.Status.DefaultUser.ServiceReference == nil {
-		return nil, fmt.Errorf("rabbit \"%s/%s\" not ready", ref.Namespace, ref.Name)
+		return nil, fmt.Errorf("rabbit \"%s/%s\" not ready", rab.Namespace, rab.Name)
 	}
 
 	_ = rab.Status.DefaultUser.SecretReference
@@ -335,4 +315,53 @@ func (r *Rabbit) RabbitMQURL(ctx context.Context, clusterRef *rabbitv1beta1.Rabb
 	}
 	host := network.GetServiceHostname(rab.Status.DefaultUser.ServiceReference.Name, rab.Status.DefaultUser.ServiceReference.Namespace)
 	return url.Parse(fmt.Sprintf("%s://%s:%s@%s:%s", protocol, username, password, host, port))
+}
+
+func (r *Rabbit) GetRabbitMQCASecret(ctx context.Context, clusterRef *rabbitv1beta1.RabbitmqClusterReference) (string, error) {
+	// TODO: add tests
+	if clusterRef.ConnectionSecret != nil {
+		s, err := r.kubeClientSet.CoreV1().Secrets(clusterRef.Namespace).Get(ctx, clusterRef.ConnectionSecret.Name, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		secretName, _ := s.Data["caSecretName"]
+		return string(secretName), nil
+	}
+
+	rabbitMQCluster, err := r.getClusterFromReference(ctx, clusterRef)
+	if err != nil {
+		return "", err
+	}
+	if rabbitMQCluster.Spec.TLS != nil {
+		return rabbitMQCluster.Spec.TLS.CASecretName, nil
+	}
+
+	return "", nil
+}
+
+func (r *Rabbit) getClusterFromReference(ctx context.Context, clusterRef *rabbitv1beta1.RabbitmqClusterReference) (*duckv1beta1.Rabbit, error) {
+	// TODO: make this better.
+	ref := &duckv1.KReference{
+		Kind:       "RabbitmqCluster",
+		APIVersion: "rabbitmq.com/v1beta1",
+		Name:       clusterRef.Name,
+		Namespace:  clusterRef.Namespace,
+	}
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	gvk := gv.WithKind(ref.Kind)
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	_, lister, err := r.rabbitLister.Get(ctx, gvr)
+	if err != nil {
+		return nil, err
+	}
+
+	o, err := lister.ByNamespace(ref.Namespace).Get(ref.Name)
+	if err != nil {
+		return nil, err
+	}
+	return o.(*duckv1beta1.Rabbit), nil
 }

--- a/pkg/rabbit/service.go
+++ b/pkg/rabbit/service.go
@@ -45,6 +45,8 @@ import (
 	"knative.dev/pkg/network"
 )
 
+const CA_SECRET_KEYNAME = "caSecretName"
+
 func New(ctx context.Context) *Rabbit {
 	return &Rabbit{
 		Interface:     rabbitmqclient.Get(ctx),
@@ -318,7 +320,6 @@ func (r *Rabbit) RabbitMQURL(ctx context.Context, clusterRef *rabbitv1beta1.Rabb
 }
 
 func (r *Rabbit) GetRabbitMQCASecret(ctx context.Context, clusterRef *rabbitv1beta1.RabbitmqClusterReference) (string, error) {
-	// TODO: add tests
 	if clusterRef == nil {
 		return "", errors.New("GetRabbitMQCASecret: nil clusterReference")
 	}
@@ -327,7 +328,7 @@ func (r *Rabbit) GetRabbitMQCASecret(ctx context.Context, clusterRef *rabbitv1be
 		if err != nil {
 			return "", err
 		}
-		return string(s.Data["caSecretName"]), nil
+		return string(s.Data[CA_SECRET_KEYNAME]), nil
 	}
 
 	rabbitMQCluster, err := r.getClusterFromReference(ctx, clusterRef)

--- a/pkg/rabbit/service.go
+++ b/pkg/rabbit/service.go
@@ -319,6 +319,9 @@ func (r *Rabbit) RabbitMQURL(ctx context.Context, clusterRef *rabbitv1beta1.Rabb
 
 func (r *Rabbit) GetRabbitMQCASecret(ctx context.Context, clusterRef *rabbitv1beta1.RabbitmqClusterReference) (string, error) {
 	// TODO: add tests
+	if clusterRef == nil {
+		return "", errors.New("GetRabbitMQCASecret: nil clusterReference")
+	}
 	if clusterRef.ConnectionSecret != nil {
 		s, err := r.kubeClientSet.CoreV1().Secrets(clusterRef.Namespace).Get(ctx, clusterRef.ConnectionSecret.Name, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/rabbit/types.go
+++ b/pkg/rabbit/types.go
@@ -36,4 +36,5 @@ type Service interface {
 	ReconcileBrokerDLXPolicy(context.Context, *QueueArgs) (Result, error)
 	ReconcileDLQPolicy(context.Context, *QueueArgs) (Result, error)
 	DeleteResource(ctx context.Context, args *DeleteResourceArgs) error
+	GetRabbitMQCASecret(ctx context.Context, clusterRef *rabbitv1beta1.RabbitmqClusterReference) (string, error)
 }

--- a/pkg/reconciler/broker/resources/dispatcher.go
+++ b/pkg/reconciler/broker/resources/dispatcher.go
@@ -46,13 +46,14 @@ type DispatcherArgs struct {
 	Broker   *eventingv1.Broker
 	Image    string
 	//ServiceAccountName string
-	RabbitMQHost       string
-	RabbitMQSecretName string
-	QueueName          string
-	BrokerUrlSecretKey string
-	BrokerIngressURL   *apis.URL
-	Subscriber         *apis.URL
-	Configs            reconcilersource.ConfigAccessor
+	RabbitMQHost         string
+	RabbitMQSecretName   string
+	RabbitMQCASecretName string
+	QueueName            string
+	BrokerUrlSecretKey   string
+	BrokerIngressURL     *apis.URL
+	Subscriber           *apis.URL
+	Configs              reconcilersource.ConfigAccessor
 }
 
 func DispatcherName(brokerName string) string {
@@ -132,7 +133,7 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 				})
 		}
 	}
-	return &appsv1.Deployment{
+	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: args.Broker.Namespace,
 			Name:      DispatcherName(args.Broker.Name),
@@ -175,6 +176,25 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 			},
 		},
 	}
+
+	if args.RabbitMQCASecretName != "" {
+		deployment.Spec.Template.Spec.Volumes = []corev1.Volume{{
+			Name: "rabbitmq-ca",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: args.RabbitMQCASecretName,
+				},
+			},
+		}}
+
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+			{
+				MountPath: "/etc/ssl/certs/",
+				Name:      "rabbitmq-ca",
+			}}
+	}
+
+	return deployment
 }
 
 // DispatcherLabels generates the labels present on all resources representing the dispatcher of the given

--- a/pkg/reconciler/source/rabbitmqsource.go
+++ b/pkg/reconciler/source/rabbitmqsource.go
@@ -212,15 +212,21 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1alpha1.Rab
 		logging.FromContext(ctx).Error("error while converting metrics config to JSON", zap.Any("receiveAdapter", err))
 	}
 
+	secretName, err := r.rabbit.GetRabbitMQCASecret(ctx, src.Spec.RabbitmqClusterReference)
+	if err != nil {
+		return nil, err
+	}
+
 	raArgs := resources.ReceiveAdapterArgs{
-		Image:              r.receiveAdapterImage,
-		Source:             src,
-		Labels:             resources.GetLabels(src.Name),
-		SinkURI:            sinkURI.String(),
-		MetricsConfig:      metricsConfig,
-		LoggingConfig:      loggingConfig,
-		RabbitMQSecretName: rabbit.SecretName(src.Name, "source"),
-		BrokerUrlSecretKey: rabbit.BrokerURLSecretKey,
+		Image:                r.receiveAdapterImage,
+		Source:               src,
+		Labels:               resources.GetLabels(src.Name),
+		SinkURI:              sinkURI.String(),
+		MetricsConfig:        metricsConfig,
+		LoggingConfig:        loggingConfig,
+		RabbitMQSecretName:   rabbit.SecretName(src.Name, "source"),
+		RabbitMQCASecretName: secretName,
+		BrokerUrlSecretKey:   rabbit.BrokerURLSecretKey,
 	}
 	expected := resources.MakeReceiveAdapter(&raArgs)
 

--- a/pkg/reconciler/trigger/resources/dispatcher_test.go
+++ b/pkg/reconciler/trigger/resources/dispatcher_test.go
@@ -135,6 +135,14 @@ func deployment(opts ...func(*appsv1.Deployment)) *appsv1.Deployment {
 					},
 				},
 				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: "rabbitmq-ca",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "rabbitmq-ca-secret",
+							},
+						},
+					}},
 					Containers: []corev1.Container{{
 						Name:  "dispatcher",
 						Image: image,
@@ -146,6 +154,11 @@ func deployment(opts ...func(*appsv1.Deployment)) *appsv1.Deployment {
 								corev1.ResourceCPU:    resource.MustParse("4000m"),
 								corev1.ResourceMemory: resource.MustParse("600Mi")},
 						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/etc/ssl/certs/",
+								Name:      "rabbitmq-ca",
+							}},
 						Env: []corev1.EnvVar{{
 							Name:  system.NamespaceEnvKey,
 							Value: system.Namespace(),
@@ -223,14 +236,15 @@ func dispatcherArgs(opts ...func(*DispatcherArgs)) *DispatcherArgs {
 		Spec:       eventingv1.TriggerSpec{Broker: brokerName},
 	}
 	args := &DispatcherArgs{
-		Trigger:            trigger,
-		Image:              image,
-		RabbitMQHost:       rabbitHost,
-		RabbitMQSecretName: secretName,
-		QueueName:          queueName,
-		BrokerUrlSecretKey: brokerURLKey,
-		BrokerIngressURL:   ingressURL,
-		Subscriber:         sURL,
+		Trigger:              trigger,
+		Image:                image,
+		RabbitMQHost:         rabbitHost,
+		RabbitMQSecretName:   secretName,
+		RabbitMQCASecretName: "rabbitmq-ca-secret",
+		QueueName:            queueName,
+		BrokerUrlSecretKey:   brokerURLKey,
+		BrokerIngressURL:     ingressURL,
+		Subscriber:           sURL,
 	}
 	for _, o := range opts {
 		o(args)

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -257,6 +257,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithFilter(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 					markReady(createQueue(config, false)),
 					markReady(createBinding(true, false)),
 				},
@@ -274,6 +275,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithFilter(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 					markReady(createQueue(config, false)),
 					markReady(createBinding(true, false)),
 				},
@@ -292,6 +294,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithDeliverySpec(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 					markReady(createQueue(config, false)),
 					markReady(createBinding(true, false)),
 				},
@@ -386,6 +389,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithFilter(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 					markReady(createQueue(config, false)),
 					markReady(createBinding(true, false)),
 				},
@@ -408,6 +412,7 @@ func TestReconcile(t *testing.T) {
 						WithTriggerSubscriberRef(subscriberGVK, subscriberName, testNS)),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 				},
 				WantCreates: []runtime.Object{
 					createDispatcherDeployment(false),
@@ -461,6 +466,7 @@ func TestReconcile(t *testing.T) {
 						WithTriggerSubscriberURI(subscriberURI)),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 					markReady(createQueue(config, false)),
 					markReady(createBinding(false, false)),
 				},
@@ -496,6 +502,7 @@ func TestReconcile(t *testing.T) {
 						WithTriggerSubscriberURI(subscriberURI)),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 					createDifferentDispatcherDeployment(),
 					markReady(createQueue(config, false)),
 					markReady(createBinding(false, false)),
@@ -532,6 +539,7 @@ func TestReconcile(t *testing.T) {
 						WithTriggerSubscriberURI(subscriberURI)),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 					markReady(createQueue(config, false)),
 					markReady(createBinding(false, false)),
 					createDispatcherDeployment(false),
@@ -556,6 +564,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithFilter(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 					markReady(createQueue(config, false)),
 					markReady(createBinding(true, false)),
 					createDispatcherDeployment(false),
@@ -722,6 +731,7 @@ func TestReconcile(t *testing.T) {
 					),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 					markReady(createQueue(config, false)),
 					markReady(createBinding(false, false)),
 				},
@@ -754,6 +764,7 @@ func TestReconcile(t *testing.T) {
 						WithTriggerSubscriberURI(subscriberURI)),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 					markReady(createQueue(config, false)),
 					markReady(createBinding(false, false)),
 					createDispatcherDeploymentWithParallelism(),
@@ -782,6 +793,7 @@ func TestReconcile(t *testing.T) {
 					triggerWithFilter(),
 					createSecret(rabbitURL),
 					createRabbitMQBrokerConfig(),
+					createRabbitMQCluster(),
 					markReady(createQueue(config, true)),
 					markReady(createBinding(true, false)),
 					markReady(createQueue(config, false)),
@@ -1214,6 +1226,20 @@ func makeSubscriberNotAddressableAsUnstructured() *unstructured.Unstructured {
 			"metadata": map[string]interface{}{
 				"namespace": testNS,
 				"name":      subscriberName,
+			},
+		},
+	}
+}
+
+func createRabbitMQCluster() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rabbitmq.com/v1beta1",
+			"kind":       "RabbitmqCluster",
+			"metadata": map[string]interface{}{
+				"creationTimestamp": nil,
+				"namespace":         testNS,
+				"name":              rabbitMQBrokerName,
 			},
 		},
 	}


### PR DESCRIPTION
# Changes

- 🎁 Broker -> RabbitMQ TLS communication with self-signed certs
- Requires `RabbitMQCluster.Spec.TLS.CASecretName` to be set to a secret containing the ca.cert
- Requires `caSecretName` as an extra field when using a `connectionSecret` instead of RabbitMQCluster

/kind enhancement


Fixes #883 

**Release Note**

```release-note
- Eventing-rabbitmq can be used with a RabbitMQ server which uses self-signed certs
```

Docs and e2e tests in a follow-up PR