### PR TITLE
Resource request and limits can be set for Broker, Trigger and Source

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_validation.go
+++ b/pkg/apis/eventing/v1alpha1/broker_validation.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"knative.dev/eventing-rabbitmq/pkg/utils"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
@@ -74,6 +75,11 @@ func (b *RabbitBroker) Validate(ctx context.Context) *apis.FieldError {
 		}
 		return nil
 	}
+
+	if apiErr := utils.ValidateResourceRequestsAndLimits(b.ObjectMeta); apiErr != nil {
+		return apiErr
+	}
+
 	var errs *apis.FieldError
 	if b.Spec.Config == nil {
 		return apis.ErrMissingField("config").ViaField("spec")

--- a/pkg/apis/eventing/v1alpha1/broker_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/broker_validation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"knative.dev/eventing-rabbitmq/pkg/utils"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -276,6 +277,21 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		}},
+	}, {
+		name: "invalid resource annotations",
+		b: RabbitBroker{eventingv1.Broker{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"eventing.knative.dev/broker.class": "RabbitMQBroker",
+					utils.CPURequestAnnotation:          "invalid",
+				},
+			},
+		}},
+		want: &apis.FieldError{
+			Message: "Failed to parse quantity from rabbitmq.eventing.knative.dev/cpu-request",
+			Paths:   []string{"metadata", "annotations", "rabbitmq.eventing.knative.dev/cpu-request"},
+			Details: "quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'",
+		},
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/apis/eventing/v1alpha1/trigger_validation.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_validation.go
@@ -22,6 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"knative.dev/eventing-rabbitmq/pkg/utils"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/eventing/pkg/client/clientset/versioned"
 	"knative.dev/eventing/pkg/client/injection/client"
@@ -78,6 +79,10 @@ func (t *RabbitTrigger) Validate(ctx context.Context) *apis.FieldError {
 		if parallelismInt < 1 || parallelismInt > 1000 {
 			return apis.ErrOutOfBoundsValue(parallelismInt, 1, 1000, parallelismAnnotation)
 		}
+	}
+
+	if apiErr := utils.ValidateResourceRequestsAndLimits(t.ObjectMeta); apiErr != nil {
+		return apiErr
 	}
 
 	if apis.IsInUpdate(ctx) {

--- a/pkg/apis/sources/v1alpha1/rabbitmq_validation.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_validation.go
@@ -42,6 +42,10 @@ func (current *RabbitmqSource) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
+	if apiErr := utils.ValidateResourceRequestsAndLimits(current.ObjectMeta); apiErr != nil {
+		return apiErr
+	}
+
 	if current.Spec.RabbitmqResourcesConfig == nil {
 		return apis.ErrMissingField("rabbitmqResourcesConfig").ViaField("spec")
 	} else {

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/eventing-rabbitmq/pkg/rabbit"
 	naming "knative.dev/eventing-rabbitmq/pkg/rabbitmqnaming"
 	"knative.dev/eventing-rabbitmq/pkg/reconciler/broker/resources"
+	"knative.dev/eventing-rabbitmq/pkg/utils"
 	rabbitclientset "knative.dev/eventing-rabbitmq/third_party/pkg/client/clientset/versioned"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	clientset "knative.dev/eventing/pkg/client/clientset/versioned"
@@ -191,6 +192,10 @@ func (r *Reconciler) reconcileIngressDeployment(ctx context.Context, b *eventing
 	if err != nil {
 		return err
 	}
+	resourceRequirements, err := utils.GetResourceRequirements(b.ObjectMeta)
+	if err != nil {
+		return err
+	}
 
 	expected := resources.MakeIngressDeployment(&resources.IngressArgs{
 		Broker:               b,
@@ -199,6 +204,7 @@ func (r *Reconciler) reconcileIngressDeployment(ctx context.Context, b *eventing
 		RabbitMQCASecretName: secretName,
 		BrokerUrlSecretKey:   rabbit.BrokerURLSecretKey,
 		Configs:              r.configs,
+		ResourceRequirements: resourceRequirements,
 	})
 	return r.reconcileDeployment(ctx, expected)
 }
@@ -221,6 +227,10 @@ func (r *Reconciler) reconcileDLXDispatcherDeployment(ctx context.Context, b *ev
 		if err != nil {
 			return err
 		}
+		requirements, err := utils.GetResourceRequirements(b.ObjectMeta)
+		if err != nil {
+			return err
+		}
 		expected := resources.MakeDispatcherDeployment(&resources.DispatcherArgs{
 			Broker: b,
 			Image:  r.dispatcherImage,
@@ -233,6 +243,7 @@ func (r *Reconciler) reconcileDLXDispatcherDeployment(ctx context.Context, b *ev
 			Subscriber:           sub,
 			BrokerIngressURL:     b.Status.Address.URL,
 			Configs:              r.configs,
+			ResourceRequirements: requirements,
 		})
 		return r.reconcileDeployment(ctx, expected)
 	}

--- a/pkg/reconciler/broker/broker_test_helper.go
+++ b/pkg/reconciler/broker/broker_test_helper.go
@@ -223,12 +223,16 @@ func WithIngressAvailable() BrokerOption {
 }
 
 func WithBrokerClass(bc string) BrokerOption {
+	return WithAnnotation(broker.ClassAnnotationKey, bc)
+}
+
+func WithAnnotation(key, value string) BrokerOption {
 	return func(b *v1.Broker) {
 		annotations := b.GetAnnotations()
 		if annotations == nil {
 			annotations = make(map[string]string, 1)
 		}
-		annotations[broker.ClassAnnotationKey] = bc
+		annotations[key] = value
 		b.SetAnnotations(annotations)
 	}
 }

--- a/pkg/reconciler/broker/resources/dispatcher.go
+++ b/pkg/reconciler/broker/resources/dispatcher.go
@@ -54,6 +54,7 @@ type DispatcherArgs struct {
 	BrokerIngressURL     *apis.URL
 	Subscriber           *apis.URL
 	Configs              reconcilersource.ConfigAccessor
+	ResourceRequirements corev1.ResourceRequirements
 }
 
 func DispatcherName(brokerName string) string {
@@ -133,6 +134,19 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 				})
 		}
 	}
+	// Default requirements only if none of the requirements are set through annotations
+	if len(args.ResourceRequirements.Limits) == 0 && len(args.ResourceRequirements.Requests) == 0 {
+		// This resource requests and limits comes from performance testing 1500msgs/s with a parallelism of 1000
+		// more info in this issue: https://github.com/knative-sandbox/eventing-rabbitmq/issues/703
+		args.ResourceRequirements = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi")},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4000m"),
+				corev1.ResourceMemory: resource.MustParse("600Mi")},
+		}
+	}
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: args.Broker.Namespace,
@@ -154,23 +168,10 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 				Spec: corev1.PodSpec{
 					//ServiceAccountName: args.ServiceAccountName,
 					Containers: []corev1.Container{{
-						Name:  dispatcherContainerName,
-						Image: args.Image,
-						Env:   envs,
-						// This resource requests and limits comes from performance testing 1500msgs/s with a parallelism of 1000
-						// more info in this issue: https://github.com/knative-sandbox/eventing-rabbitmq/issues/703
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("50m"),
-								corev1.ResourceMemory: resource.MustParse("64Mi")},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("4000m"),
-								corev1.ResourceMemory: resource.MustParse("600Mi")},
-						},
-						Ports: []corev1.ContainerPort{{
-							Name:          "http-metrics",
-							ContainerPort: 9090,
-						}},
+						Name:      dispatcherContainerName,
+						Image:     args.Image,
+						Env:       envs,
+						Resources: args.ResourceRequirements,
 					}},
 				},
 			},

--- a/pkg/reconciler/broker/resources/dispatcher.go
+++ b/pkg/reconciler/broker/resources/dispatcher.go
@@ -172,6 +172,10 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 						Image:     args.Image,
 						Env:       envs,
 						Resources: args.ResourceRequirements,
+						Ports: []corev1.ContainerPort{{
+							Name:          "http-metrics",
+							ContainerPort: 9090,
+						}},
 					}},
 				},
 			},

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -32,6 +32,7 @@ import (
 	"knative.dev/eventing-rabbitmq/pkg/rabbit"
 	naming "knative.dev/eventing-rabbitmq/pkg/rabbitmqnaming"
 	"knative.dev/eventing-rabbitmq/pkg/reconciler/trigger/resources"
+	"knative.dev/eventing-rabbitmq/pkg/utils"
 	rabbitv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 	rabbitclientset "knative.dev/eventing-rabbitmq/third_party/pkg/client/clientset/versioned"
 	rabbitlisters "knative.dev/eventing-rabbitmq/third_party/pkg/client/listers/rabbitmq.com/v1beta1"
@@ -397,6 +398,10 @@ func (r *Reconciler) reconcileDispatcherDeployment(ctx context.Context, t *event
 	if err != nil {
 		return nil, err
 	}
+	resourceRequirements, err := utils.GetResourceRequirements(t.ObjectMeta)
+	if err != nil {
+		return nil, err
+	}
 
 	expected := resources.MakeDispatcherDeployment(&resources.DispatcherArgs{
 		Trigger:              t,
@@ -410,6 +415,7 @@ func (r *Reconciler) reconcileDispatcherDeployment(ctx context.Context, t *event
 		DLX:                  dlq,
 		Delivery:             delivery,
 		Configs:              r.configs,
+		ResourceRequirements: resourceRequirements,
 	})
 	return r.reconcileDeployment(ctx, expected)
 }

--- a/pkg/utils/resource_requirements.go
+++ b/pkg/utils/resource_requirements.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+const (
+	CPURequestAnnotation    = "rabbitmq.eventing.knative.dev/cpu-request"
+	CPULimitAnnotation      = "rabbitmq.eventing.knative.dev/cpu-limit"
+	MemoryRequestAnnotation = "rabbitmq.eventing.knative.dev/memory-request"
+	MemoryLimitAnnotation   = "rabbitmq.eventing.knative.dev/memory-limit"
+)
+
+func ValidateResourceRequestsAndLimits(obj metav1.ObjectMeta) *apis.FieldError {
+	cpuRequest, apiErr := parseResource(obj, CPURequestAnnotation)
+	if apiErr != nil {
+		return apiErr
+	}
+	cpuLimit, apiErr := parseResource(obj, CPULimitAnnotation)
+	if apiErr != nil {
+		return apiErr
+	}
+	if cpuRequest != nil && cpuLimit != nil {
+		if cpuRequest.Cmp(*cpuLimit) > 0 {
+			return &apis.FieldError{
+				Message: "request must be less than or equal to limit",
+				Paths:   []string{"metadata", "annotations"},
+			}
+		}
+	}
+
+	memRequest, apiErr := parseResource(obj, MemoryRequestAnnotation)
+	if apiErr != nil {
+		return apiErr
+	}
+	memLimit, apiErr := parseResource(obj, MemoryLimitAnnotation)
+	if apiErr != nil {
+		return apiErr
+	}
+	if memRequest != nil && memLimit != nil {
+		if memRequest.Cmp(*memLimit) > 0 {
+			return &apis.FieldError{
+				Message: "request must be less than or equal to limit",
+				Paths:   []string{"metadata", "annotations"},
+			}
+		}
+	}
+	return nil
+}
+
+func GetResourceRequirements(obj metav1.ObjectMeta) (corev1.ResourceRequirements, error) {
+	requirements := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{},
+		Limits:   corev1.ResourceList{},
+	}
+	if apiErr := ValidateResourceRequestsAndLimits(obj); apiErr != nil {
+		return requirements, errors.New(apiErr.Details)
+	}
+
+	// No need to check for errors as the validation happens above
+	if cpuRequest, _ := parseResource(obj, CPURequestAnnotation); cpuRequest != nil {
+		requirements.Requests[corev1.ResourceCPU] = *cpuRequest
+	}
+	if cpuLimit, _ := parseResource(obj, CPULimitAnnotation); cpuLimit != nil {
+		requirements.Limits[corev1.ResourceCPU] = *cpuLimit
+	}
+	if memRequest, _ := parseResource(obj, MemoryRequestAnnotation); memRequest != nil {
+		requirements.Requests[corev1.ResourceMemory] = *memRequest
+	}
+	if memLimit, _ := parseResource(obj, MemoryLimitAnnotation); memLimit != nil {
+		requirements.Limits[corev1.ResourceMemory] = *memLimit
+	}
+
+	return requirements, nil
+}
+
+func parseResource(obj metav1.ObjectMeta, annotation string) (*resource.Quantity, *apis.FieldError) {
+	quantity, ok := obj.GetAnnotations()[annotation]
+	if ok {
+		q, err := resource.ParseQuantity(quantity)
+		if err != nil {
+			return nil, &apis.FieldError{
+				Message: fmt.Sprintf("Failed to parse quantity from %s", annotation),
+				Paths:   []string{"metadata", "annotations", annotation},
+				Details: err.Error(),
+			}
+		}
+		return &q, nil
+	}
+
+	return nil, nil
+}

--- a/pkg/utils/resource_requirements_test.go
+++ b/pkg/utils/resource_requirements_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateResourceRequestsAndLimits(t *testing.T) {
+	testCases := map[string]struct {
+		obj     metav1.ObjectMeta
+		wantErr bool
+	}{
+		"empty meta should not cause error": {
+			obj:     metav1.ObjectMeta{},
+			wantErr: false,
+		},
+		"CPU request bad format": {
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					CPURequestAnnotation: "invalid",
+				},
+			},
+			wantErr: true,
+		},
+		"CPU limit bad format": {
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					CPULimitAnnotation: "invalid",
+				},
+			},
+			wantErr: true,
+		},
+		"Memory request bad format": {
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					MemoryRequestAnnotation: "invalid",
+				},
+			},
+			wantErr: true,
+		},
+		"Memory limit bad format": {
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					MemoryLimitAnnotation: "invalid",
+				},
+			},
+			wantErr: true,
+		},
+		"CPU request is greater than limit": {
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					CPURequestAnnotation: "50m",
+					CPULimitAnnotation:   "25m",
+				},
+			},
+			wantErr: true,
+		},
+		"Memory request is greater than limit": {
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					MemoryRequestAnnotation: "50M",
+					MemoryLimitAnnotation:   "25M",
+				},
+			},
+			wantErr: true,
+		},
+		"no error when all set correctly": {
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					CPURequestAnnotation:    "25m",
+					CPULimitAnnotation:      "50m",
+					MemoryRequestAnnotation: "50M",
+					MemoryLimitAnnotation:   "50M",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			err := ValidateResourceRequestsAndLimits(tc.obj)
+			if err == nil && tc.wantErr {
+				t.Error("expected error but got nil")
+			} else if err != nil && !tc.wantErr {
+				t.Errorf("got error %s, when not expecting error", err.Error())
+			}
+		})
+	}
+}
+
+func TestGetResourceRequirements(t *testing.T) {
+	testCases := map[string]struct {
+		obj                  metav1.ObjectMeta
+		wantErr              bool
+		expectedRequirements corev1.ResourceRequirements
+	}{
+		"returns error when validation fails": {
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					CPURequestAnnotation: "invalid",
+				},
+			},
+			wantErr: true,
+		},
+		"parses resources and requests properly. no error": {
+			obj: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					CPURequestAnnotation:    "25m",
+					CPULimitAnnotation:      "50m",
+					MemoryRequestAnnotation: "50M",
+					MemoryLimitAnnotation:   "50M",
+				},
+			},
+			wantErr: false,
+			expectedRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("25m"),
+					corev1.ResourceMemory: resource.MustParse("50M"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("50m"),
+					corev1.ResourceMemory: resource.MustParse("50M"),
+				},
+			},
+		},
+		"empty resource requirements when annotations don't exist. no error": {
+			obj:     metav1.ObjectMeta{},
+			wantErr: false,
+			expectedRequirements: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{},
+				Limits:   corev1.ResourceList{},
+			},
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			actualRequirements, err := GetResourceRequirements(tc.obj)
+			if err == nil && tc.wantErr {
+				t.Error("expected error but got nil")
+			} else if err != nil && !tc.wantErr {
+				t.Errorf("got error %s, when not expecting error", err.Error())
+			}
+
+			if !tc.wantErr {
+				if !reflect.DeepEqual(actualRequirements, tc.expectedRequirements) {
+					t.Errorf("actual and expected requirements not equal. Actual: %v, Expected: %v", actualRequirements, tc.expectedRequirements)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- 🎁 Pod resource requests can be set for Broker, Trigger and RabbitmqSource through annotations


/kind enhancement


Fixes #823 

```release-note
Pod resource requests can be set for Broker, Trigger and RabbitmqSource through annotations
```

