### PR TITLE
Fix Source log leak when predeclared resources are not created

### DIFF
--- a/pkg/rabbit/types.go
+++ b/pkg/rabbit/types.go
@@ -21,6 +21,8 @@ import (
 	"net/url"
 
 	rabbitv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
+
+	rmqv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/client/clientset/versioned/typed/rabbitmq.com/v1beta1"
 )
 
 type Result struct {
@@ -29,6 +31,7 @@ type Result struct {
 }
 
 type Service interface {
+	RabbitmqV1beta1() rmqv1beta1.RabbitmqV1beta1Interface
 	RabbitMQURL(context.Context, *rabbitv1beta1.RabbitmqClusterReference) (*url.URL, error)
 	ReconcileExchange(context.Context, *ExchangeArgs) (Result, error)
 	ReconcileQueue(context.Context, *QueueArgs) (Result, error)

--- a/pkg/reconciler/source/rabbitmqsource.go
+++ b/pkg/reconciler/source/rabbitmqsource.go
@@ -154,6 +154,18 @@ func (r *Reconciler) reconcileRabbitObjects(ctx context.Context, src *v1alpha1.R
 	src.Status.MarkSecretReady()
 
 	if src.Spec.RabbitmqResourcesConfig.Predeclared {
+		_, err := r.rabbit.RabbitmqV1beta1().Exchanges(src.Namespace).Get(ctx, src.Spec.RabbitmqResourcesConfig.ExchangeName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			logger.Error("exchange not found", "exchange", src.Spec.RabbitmqResourcesConfig.ExchangeName)
+			return err
+		}
+
+		_, err = r.rabbit.RabbitmqV1beta1().Queues(src.Namespace).Get(ctx, src.Spec.RabbitmqResourcesConfig.QueueName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			logger.Error("queue not found", "queue", src.Spec.RabbitmqResourcesConfig.QueueName)
+			return err
+		}
+
 		logger.Info("predeclared set to true; no RabbitMQ objects to reconcile",
 			"source", src.Name,
 			"predeclared queue", src.Spec.RabbitmqResourcesConfig.QueueName)


### PR DESCRIPTION
Added queue and exchange existence verification to source controller to avoid not existing errors

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🐛 Fix Source log leak when predeclared resources are not created

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #939 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
🐛 Fix Source log leak when predeclared resources are not created
```

