### PR TITLE
Fix: Capitalize ALL when dropping capabilities.

### DIFF
--- a/pkg/reconciler/broker/resources/dispatcher.go
+++ b/pkg/reconciler/broker/resources/dispatcher.go
@@ -182,7 +182,7 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 							ReadOnlyRootFilesystem:   ptr.Bool(true),
 							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"all"},
+								Drop: []corev1.Capability{"ALL"},
 							},
 						},
 					}},

--- a/pkg/reconciler/broker/resources/dispatcher_test.go
+++ b/pkg/reconciler/broker/resources/dispatcher_test.go
@@ -128,7 +128,7 @@ func TestMakeDispatcherDeployment(t *testing.T) {
 							ReadOnlyRootFilesystem:   ptr.Bool(true),
 							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"all"},
+								Drop: []corev1.Capability{"ALL"},
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{

--- a/pkg/reconciler/broker/resources/ingress.go
+++ b/pkg/reconciler/broker/resources/ingress.go
@@ -144,7 +144,7 @@ func MakeIngressDeployment(args *IngressArgs) *appsv1.Deployment {
 							ReadOnlyRootFilesystem:   ptr.Bool(true),
 							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"all"},
+								Drop: []corev1.Capability{"ALL"},
 							},
 						},
 					}},

--- a/pkg/reconciler/broker/resources/ingress_test.go
+++ b/pkg/reconciler/broker/resources/ingress_test.go
@@ -106,7 +106,7 @@ func TestMakeIngressDeployment(t *testing.T) {
 							ReadOnlyRootFilesystem:   ptr.Bool(true),
 							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"all"},
+								Drop: []corev1.Capability{"ALL"},
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{{

--- a/pkg/reconciler/source/resources/receive_adapter.go
+++ b/pkg/reconciler/source/resources/receive_adapter.go
@@ -182,7 +182,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 							ReadOnlyRootFilesystem:   ptr.Bool(true),
 							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"all"},
+								Drop: []corev1.Capability{"ALL"},
 							},
 						},
 					}},

--- a/pkg/reconciler/source/resources/receive_adapter_test.go
+++ b/pkg/reconciler/source/resources/receive_adapter_test.go
@@ -159,7 +159,7 @@ func TestMakeReceiveAdapter(t *testing.T) {
 										ReadOnlyRootFilesystem:   ptr.Bool(true),
 										RunAsNonRoot:             ptr.Bool(true),
 										Capabilities: &corev1.Capabilities{
-											Drop: []corev1.Capability{"all"},
+											Drop: []corev1.Capability{"ALL"},
 										},
 									},
 									VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
:bug: It turns out that "all" is wrong and only "ALL" is accepted by Kubernetes.

ref: https://github.com/knative-sandbox/eventing-rabbitmq/pull/954#discussion_r1003456924

/kind bug

**Release Note**

```release-note
Switch from all -> ALL in securityContext when dropping capabilities.
```

**Docs**

```docs
NONE
```

cc @gab-satchi @gabo1208 @matzew 
