### PR TITLE
Fix: Add `securityContext` to Trigger dispatcher.

### DIFF
--- a/pkg/reconciler/trigger/resources/dispatcher.go
+++ b/pkg/reconciler/trigger/resources/dispatcher.go
@@ -32,6 +32,7 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
 )
 
@@ -118,6 +119,14 @@ func MakeDispatcherDeployment(args *DispatcherArgs) *appsv1.Deployment {
 			Name:          "http-metrics",
 			ContainerPort: 9090,
 		}},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.Bool(false),
+			ReadOnlyRootFilesystem:   ptr.Bool(true),
+			RunAsNonRoot:             ptr.Bool(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		},
 	}
 	if args.Configs != nil {
 		dispatcher.Env = append(dispatcher.Env, args.Configs.ToEnvVars()...)

--- a/pkg/reconciler/trigger/resources/dispatcher_test.go
+++ b/pkg/reconciler/trigger/resources/dispatcher_test.go
@@ -215,6 +215,14 @@ func deployment(opts ...func(*appsv1.Deployment)) *appsv1.Deployment {
 							Name:          "http-metrics",
 							ContainerPort: 9090,
 						}},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							ReadOnlyRootFilesystem:   ptr.Bool(true),
+							RunAsNonRoot:             ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+						},
 					}},
 				},
 			},


### PR DESCRIPTION
:bug: I was puzzled when picking up 1.8 that the ingress warnings went away, but the "dispatcher" warnings stuck around in GKE security posture.

Turns out there are two places calling things "dispatcher" :facepalm: so this fixes the other, which was also missed in the later source cleanup.

/kind bug

**Release Note**

```release-note
Set securityContext for the trigger resources' dispatcher deployments.
```

**Docs**

```docs

```

/cc @gab-satchi @gabo1208
cc @evankanderson @matzew @vaikas