### PR TITLE
ClusterRef Default Namespace fix

### DIFF
--- a/cmd/webhook/broker/main.go
+++ b/cmd/webhook/broker/main.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2021 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/cmd/webhook/broker/main.go
+++ b/cmd/webhook/broker/main.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2021 The Knative Authors
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,6 +28,7 @@ import (
 	"knative.dev/pkg/webhook"
 	"knative.dev/pkg/webhook/certificates"
 	"knative.dev/pkg/webhook/resourcesemantics"
+	"knative.dev/pkg/webhook/resourcesemantics/defaulting"
 	"knative.dev/pkg/webhook/resourcesemantics/validation"
 
 	rabbitv1 "knative.dev/eventing-rabbitmq/pkg/apis/eventing/v1alpha1"
@@ -41,6 +39,33 @@ var ourTypes = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	v1.SchemeGroupVersion.WithKind("Broker"):                                                             &rabbitv1.RabbitBroker{},
 	v1.SchemeGroupVersion.WithKind("Trigger"):                                                            &v1.Trigger{},
 	schema.GroupVersion{Group: eventing.GroupName, Version: "v1alpha1"}.WithKind("RabbitmqBrokerConfig"): &rabbitv1.RabbitmqBrokerConfig{},
+}
+
+func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	// A function that infuses the context passed to ConvertTo/ConvertFrom/SetDefaults with custom metadata.
+	ctxFunc := func(ctx context.Context) context.Context {
+		return ctx
+	}
+
+	return defaulting.NewAdmissionController(ctx,
+
+		// Name of the resource webhook.
+		"defaulting.webhook.rabbitmq.eventing.knative.dev",
+
+		// The path on which to serve the webhook.
+		"/defaulting",
+
+		// The resources to default.
+		map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
+			schema.GroupVersion{Group: eventing.GroupName, Version: "v1alpha1"}.WithKind("RabbitmqBrokerConfig"): &rabbitv1.RabbitmqBrokerConfig{},
+		},
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		ctxFunc,
+
+		// Whether to disallow unknown fields.
+		true,
+	)
 }
 
 func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
@@ -91,5 +116,6 @@ func main() {
 	sharedmain.WebhookMainWithContext(ctx, "rabbitmq-broker-webhook",
 		certificates.NewController,
 		NewValidationAdmissionController,
+		NewDefaultingAdmissionController,
 	)
 }

--- a/config/broker/500-webhook-defaulting.yaml
+++ b/config/broker/500-webhook-defaulting.yaml
@@ -1,0 +1,31 @@
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: defaulting.webhook.rabbitmq.eventing.knative.dev
+  labels:
+    rabbitmq.eventing.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions: ["v1", "v1alpha1"]
+  clientConfig:
+    service:
+      name: rabbitmq-broker-webhook
+      namespace: knative-eventing
+  sideEffects: None
+  failurePolicy: Fail
+  name: defaulting.webhook.rabbitmq.eventing.knative.dev
+  timeoutSeconds: 2
+  

--- a/config/broker/500-webhook-defaulting.yaml
+++ b/config/broker/500-webhook-defaulting.yaml
@@ -28,4 +28,3 @@ webhooks:
   failurePolicy: Fail
   name: defaulting.webhook.rabbitmq.eventing.knative.dev
   timeoutSeconds: 2
-  

--- a/pkg/apis/eventing/v1alpha1/rabbitmq_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/rabbitmq_defaults.go
@@ -20,6 +20,6 @@ import "context"
 
 func (r *RabbitmqBrokerConfig) SetDefaults(ctx context.Context) {
 	if r.Spec.RabbitmqClusterReference != nil && r.Spec.RabbitmqClusterReference.Namespace == "" {
-		r.Spec.RabbitmqClusterReference.Namespace = "default"
+		r.Spec.RabbitmqClusterReference.Namespace = r.Namespace
 	}
 }

--- a/pkg/apis/eventing/v1alpha1/rabbitmq_defaults_test.go
+++ b/pkg/apis/eventing/v1alpha1/rabbitmq_defaults_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
+)
+
+const (
+	brokerConfigName = "test-broker-config"
+	clusterRefName   = "test-cluster-ref"
+	brokerConfigNS   = "test-config-namespace"
+	clusterRefNS     = "test-cluster-ref-namespace"
+)
+
+func TestBrokerConfigDefaults(t *testing.T) {
+	tests := map[string]struct {
+		clusterRefNamespace string
+		wantConfig          *RabbitmqBrokerConfig
+	}{
+		"nil clusterRef namespace": {
+			wantConfig: &RabbitmqBrokerConfig{
+				ObjectMeta: v1.ObjectMeta{Name: brokerConfigName, Namespace: brokerConfigNS},
+				Spec: RabbitmqBrokerConfigSpec{
+					RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{Name: clusterRefName, Namespace: brokerConfigNS}}},
+		},
+		"clusterRef namespace set": {
+			clusterRefNamespace: clusterRefNS,
+			wantConfig: &RabbitmqBrokerConfig{
+				ObjectMeta: v1.ObjectMeta{Name: brokerConfigName, Namespace: brokerConfigNS},
+				Spec: RabbitmqBrokerConfigSpec{
+					RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{Name: clusterRefName, Namespace: clusterRefNS}}},
+		},
+	}
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			test := test
+			t.Parallel()
+			gotConfig := &RabbitmqBrokerConfig{
+				ObjectMeta: v1.ObjectMeta{Name: brokerConfigName, Namespace: brokerConfigNS},
+				Spec: RabbitmqBrokerConfigSpec{
+					RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{Name: clusterRefName, Namespace: test.clusterRefNamespace}}}
+
+			gotConfig.SetDefaults(context.Background())
+			if gotConfig.Namespace != test.wantConfig.Namespace {
+				t.Errorf("BrokerConfig ClusterReference Namespace error want: %s,\ngot: %s) =", test.wantConfig.Namespace, gotConfig.Namespace)
+			}
+		})
+	}
+}

--- a/pkg/apis/sources/v1alpha1/rabbitmq_defaults.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_defaults.go
@@ -18,8 +18,8 @@ package v1alpha1
 
 import "context"
 
-func (r *RabbitmqSource) SetDefaults(ctx context.Context) {
-	if r.Spec.RabbitmqClusterReference != nil && r.Spec.RabbitmqClusterReference.Namespace == "" {
-		r.Spec.RabbitmqClusterReference.Namespace = "default"
+func (s *RabbitmqSource) SetDefaults(ctx context.Context) {
+	if s.Spec.RabbitmqClusterReference != nil && s.Spec.RabbitmqClusterReference.Namespace == "" {
+		s.Spec.RabbitmqClusterReference.Namespace = s.Namespace
 	}
 }

--- a/pkg/apis/sources/v1alpha1/rabbitmq_defaults_test.go
+++ b/pkg/apis/sources/v1alpha1/rabbitmq_defaults_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
+)
+
+const (
+	sourceName     = "test-source"
+	clusterRefName = "test-cluster-ref"
+	sourceNS       = "test-source-namespace"
+	clusterRefNS   = "test-cluster-ref-namespace"
+)
+
+func TestSourceDefaults(t *testing.T) {
+	tests := map[string]struct {
+		clusterRefNamespace string
+		wantConfig          *RabbitmqSource
+	}{
+		"nil clusterRef namespace": {
+			wantConfig: &RabbitmqSource{
+				ObjectMeta: v1.ObjectMeta{Name: sourceName, Namespace: sourceNS},
+				Spec: RabbitmqSourceSpec{
+					RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{Name: clusterRefName, Namespace: sourceNS}}},
+		},
+		"clusterRef namespace set": {
+			clusterRefNamespace: clusterRefNS,
+			wantConfig: &RabbitmqSource{
+				ObjectMeta: v1.ObjectMeta{Name: sourceName, Namespace: sourceNS},
+				Spec: RabbitmqSourceSpec{
+					RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{Name: clusterRefName, Namespace: clusterRefNS}}},
+		},
+	}
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			test := test
+			t.Parallel()
+			gotConfig := &RabbitmqSource{
+				ObjectMeta: v1.ObjectMeta{Name: sourceName, Namespace: sourceNS},
+				Spec: RabbitmqSourceSpec{
+					RabbitmqClusterReference: &v1beta1.RabbitmqClusterReference{Name: clusterRefName, Namespace: test.clusterRefNamespace}}}
+
+			gotConfig.SetDefaults(context.Background())
+			if gotConfig.Namespace != test.wantConfig.Namespace {
+				t.Errorf("RabbitMQSource ClusterReference Namespace error want: %s,\ngot: %s) =", test.wantConfig.Namespace, gotConfig.Namespace)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -218,9 +218,8 @@ func TestReconcile(t *testing.T) {
 	}}
 
 	brokerConfigs := map[string]*duckv1.KReference{
-		"rabbitmqClusterConfig":     rabbitmqClusterConfigRef(),
-		"rabbitmqClusterConfigNoNS": rabbitmqClusterConfigRefNoNS(),
-		"rabbitmqBrokerConfig":      rabbitmqBrokerConfigRef(),
+		"rabbitmqClusterConfig": rabbitmqClusterConfigRef(),
+		"rabbitmqBrokerConfig":  rabbitmqBrokerConfigRef(),
 	}
 
 	for configName, config := range brokerConfigs {
@@ -1190,6 +1189,52 @@ func TestReconcile(t *testing.T) {
 			},
 		}...)
 	}
+
+	table = append(table, TableTest{{
+		Name: "Created broker with DLQ and no Cluster Reference namespace",
+		Key:  testKey,
+		Objects: []runtime.Object{
+			NewBroker(brokerName, testNS,
+				WithBrokerUID(brokerUID),
+				WithBrokerClass(brokerClass),
+				WithBrokerConfig(rabbitmqClusterConfigRefNoNS()),
+				WithBrokerDelivery(delivery),
+				WithInitBrokerConditions),
+			createSecretForRabbitmqCluster(),
+			createRabbitMQCluster(),
+			createRabbitMQBrokerConfig(),
+			createReadyExchange(false),
+			createReadyExchange(true),
+			createReadyQueue(true, rabbitmqClusterConfigRefNoNS()),
+			createReadyBinding(true),
+			createReadyPolicy(),
+			rt.NewEndpoints(ingressServiceName, testNS,
+				rt.WithEndpointsLabels(IngressLabels()),
+				rt.WithEndpointsAddresses(corev1.EndpointAddress{IP: "127.0.0.1"})),
+			createExchangeSecret(),
+			createIngressDeployment(),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewBroker(brokerName, testNS,
+				WithBrokerUID(brokerUID),
+				WithBrokerClass(brokerClass),
+				WithInitBrokerConditions,
+				WithBrokerConfig(rabbitmqClusterConfigRefNoNS()),
+				WithBrokerDelivery(delivery),
+				WithIngressAvailable(),
+				WithDLXReady(),
+				WithDeadLetterSinkReady(),
+				WithDeadLetterSinkResolvedSucceeded(delivery.DeadLetterSink.URI),
+				WithSecretReady(),
+				WithBrokerAddressURI(brokerAddress),
+				WithExchangeReady()),
+		}},
+		WantCreates: []runtime.Object{
+			createIngressService(),
+			createDispatcherDeployment(),
+		},
+		WantErr: false,
+	}}...)
 
 	logger := logtesting.TestLogger(t)
 	table.Test(t, rtlisters.MakeFactory(func(ctx context.Context, listers *rtlisters.Listers, cmw configmap.Watcher) controller.Reconciler {

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -218,8 +218,9 @@ func TestReconcile(t *testing.T) {
 	}}
 
 	brokerConfigs := map[string]*duckv1.KReference{
-		"rabbitmqClusterConfig": rabbitmqClusterConfigRef(),
-		"rabbitmqBrokerConfig":  rabbitmqBrokerConfigRef(),
+		"rabbitmqClusterConfig":     rabbitmqClusterConfigRef(),
+		"rabbitmqClusterConfigNoNS": rabbitmqClusterConfigRefNoNS(),
+		"rabbitmqBrokerConfig":      rabbitmqBrokerConfigRef(),
 	}
 
 	for configName, config := range brokerConfigs {
@@ -1380,6 +1381,14 @@ func rabbitmqClusterConfigRef() *duckv1.KReference {
 	return &duckv1.KReference{
 		Name:       rabbitMQBrokerName,
 		Namespace:  testNS,
+		Kind:       "RabbitmqCluster",
+		APIVersion: "rabbitmq.com/v1beta1",
+	}
+}
+
+func rabbitmqClusterConfigRefNoNS() *duckv1.KReference {
+	return &duckv1.KReference{
+		Name:       rabbitMQBrokerName,
 		Kind:       "RabbitmqCluster",
 		APIVersion: "rabbitmq.com/v1beta1",
 	}

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -157,8 +157,9 @@ func init() {
 
 func TestReconcile(t *testing.T) {
 	brokerConfigs := map[string]*duckv1.KReference{
-		"rabbitmqClusterConfig": configWithRabbitMQCluster(),
-		"rabbitmqBrokerConfig":  configWithRabbitMQBrokerConfig(),
+		"rabbitmqClusterConfig":     configWithRabbitMQCluster(),
+		"rabbitmqClusterConfigNoNS": configWithRabbitMQBrokerConfigNoNS(),
+		"rabbitmqBrokerConfig":      configWithRabbitMQBrokerConfig(),
 	}
 	table := TableTest{
 		{
@@ -908,6 +909,15 @@ func configWithRabbitMQCluster() *duckv1.KReference {
 }
 
 func configWithRabbitMQBrokerConfig() *duckv1.KReference {
+	return &duckv1.KReference{
+		Name:       rabbitMQBrokerConfigName,
+		Namespace:  testNS,
+		Kind:       "RabbitmqBrokerConfig",
+		APIVersion: "eventing.knative.dev/v1alpha1",
+	}
+}
+
+func configWithRabbitMQBrokerConfigNoNS() *duckv1.KReference {
 	return &duckv1.KReference{
 		Name:       rabbitMQBrokerConfigName,
 		Namespace:  testNS,

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -865,7 +865,7 @@ func TestReconcile(t *testing.T) {
 
 	table = append(table, TableTest{
 		{
-			Name: fmt.Sprintf("Trigger ready with cluster reference with no namespace"),
+			Name: "Trigger ready with cluster reference with no namespace",
 			Key:  testKey,
 			Objects: []runtime.Object{
 				ReadyBroker(configWithRabbitMQBrokerConfigNoNS()),


### PR DESCRIPTION
# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🐛 When BrokerConfig Cluster reference was left blank, it didn't defaulted to its parent Broker namespace causing an error with the resources namespace

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
🐛 When BrokerConfig Cluster reference was left blank, it didn't defaulted to its parent Broker or Source namespace causing an error with the resources namespace
```