### PR TITLE
re-enable skipped e2e tests

### DIFF
--- a/test/e2e/config/brokersecret/broker.yaml
+++ b/test/e2e/config/brokersecret/broker.yaml
@@ -11,11 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .namespace }}
----
 apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -80,7 +80,6 @@ func TestBrokerDirect(t *testing.T) {
 
 // TestBrokerDirect makes sure a Broker can delivery events to a consumer by connecting to a rabbitmq instance via a connection secret
 func TestBrokerDirectWithConnectionSecret(t *testing.T) {
-	t.Skip("skipping flakey test as it fails if resources are deleted in a particular order")
 	t.Parallel()
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
@@ -161,7 +160,6 @@ func TestSourceDirect(t *testing.T) {
 
 // TestSourceDirect makes sure a source delivers events to Sink by connecting to a rabbitmq instance via a connection secret.
 func TestSourceDirectWithConnectionSecret(t *testing.T) {
-	t.Skip("skipping flakey test as it fails if resources are deleted in a particular order")
 	t.Parallel()
 
 	ctx, env := global.Environment(


### PR DESCRIPTION
The namespace being recreated in the broker yaml meant that it was being tracked as a resource for the feature. When the feature cleans up, it will delete the namespace which was deleting the RabbitmqCluster too early.