### PR TITLE
Fix RabbitMQ  connection close vs HTTP drain race during ingress shutdown (#1669) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ bin/
 .envrc
 .env
 .config
+
+# transient test output
+*.log

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ releases-envsubst:
 
 KUBECTL_RELEASES := https://github.com/kubernetes/kubernetes/tags
 # Keep this in sync with KIND_K8S_VERSION
-KUBECTL_VERSION := v1.34.3
+KUBECTL_VERSION := v1.34.4
 KUBECTL_BIN := kubectl-$(KUBECTL_VERSION)-$(platform)-$(arch_alt)
 KUBECTL_URL := https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(platform)/amd64/kubectl
 KUBECTL := $(LOCAL_BIN)/$(KUBECTL_BIN)
@@ -287,11 +287,11 @@ KO_DOCKER_REPO := kind.local
 envrc::
 	@echo 'export KO_DOCKER_REPO="$(KO_DOCKER_REPO)"'
 export KO_DOCKER_REPO
-MIN_SUPPORTED_K8S_VERSION := 1.27.3
+MIN_SUPPORTED_K8S_VERSION := 1.34.4
 KIND_K8S_VERSION ?= $(MIN_SUPPORTED_K8S_VERSION)
 export KIND_K8S_VERSION
 # Find the corresponding version digest in https://github.com/kubernetes-sigs/kind/releases
-KIND_K8S_DIGEST ?= sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
+KIND_K8S_DIGEST ?= sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48
 export KIND_K8S_DIGEST
 
 .PHONY: kind-cluster

--- a/cmd/dispatcher/main.go
+++ b/cmd/dispatcher/main.go
@@ -137,6 +137,8 @@ func main() {
 			return nil
 		},
 		rabbit.DialWrapper)
+	// close rmq connection the last
+	defer rmqHelper.Close()
 	for {
 		if err = d.ConsumeFromQueue(ctx, rmqHelper.GetConnection(), rmqHelper.GetChannel(), env.QueueName); err != nil {
 			if errors.Is(err, context.Canceled) {

--- a/cmd/ingress/main.go
+++ b/cmd/ingress/main.go
@@ -103,6 +103,8 @@ func main() {
 
 	env.rmqHelper = rabbit.NewRabbitMQConnectionHandler(5, 1000, logger)
 	env.rmqHelper.Setup(ctx, rabbit.VHostHandler(env.BrokerURL, env.RabbitMQVhost), rabbit.ChannelConfirm, rabbit.DialWrapper)
+	// close rmq connection the last
+	defer env.rmqHelper.Close()
 
 	env.tracer = otel.GetTracerProvider().Tracer(scopeName)
 

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -90,6 +90,8 @@ func (a *Adapter) start(stopCh <-chan struct{}) error {
 		a.rmqHelper = rabbit.NewRabbitMQConnectionHandler(5, 1000, logger)
 		a.rmqHelper.Setup(a.context, rabbit.VHostHandler(a.config.RabbitURL, a.config.Vhost), rabbit.ChannelQoS, rabbit.DialWrapper)
 	}
+	// close rmq connection the last
+	defer a.rmqHelper.Close()
 	return a.PollForMessages(stopCh)
 }
 

--- a/pkg/rabbit/connections_handler.go
+++ b/pkg/rabbit/connections_handler.go
@@ -30,7 +30,10 @@ import (
 type RabbitMQConnectionsHandlerInterface interface {
 	GetConnection() RabbitMQConnectionInterface
 	GetChannel() RabbitMQChannelInterface
+	// should be called exactly once
 	Setup(context.Context, string, func(RabbitMQConnectionInterface, RabbitMQChannelInterface) error, func(string) (RabbitMQConnectionWrapperInterface, error))
+	// used to explicitly Close rmq connection, not ctx.Done as before
+	Close()
 }
 
 type RabbitMQConnectionInterface interface {
@@ -55,11 +58,14 @@ type RabbitMQChannelInterface interface {
 }
 
 type RabbitMQConnectionHandler struct {
-	firstSetup                              bool
 	reconnTries, reconnectionTriesThreshold int
 	cycleDuration                           time.Duration
 	Connection                              RabbitMQConnectionWrapperInterface
 	Channel                                 RabbitMQChannelInterface
+
+	// stopCh signals the watcher to stop and tear down the connection.
+	// used instead of previous ctx.Done
+	stopCh chan struct{}
 
 	logger *zap.SugaredLogger
 }
@@ -106,8 +112,8 @@ func (r *RabbitMQConnection) IsClosed() bool {
 func NewRabbitMQConnectionHandler(reconnectionTriesThreshold int, cycleDuration time.Duration, logger *zap.SugaredLogger) RabbitMQConnectionsHandlerInterface {
 	return &RabbitMQConnectionHandler{
 		reconnectionTriesThreshold: reconnectionTriesThreshold,
-		firstSetup:                 true,
 		cycleDuration:              cycleDuration,
+		stopCh:                     make(chan struct{}),
 		logger:                     logger,
 	}
 }
@@ -118,11 +124,7 @@ func (r *RabbitMQConnectionHandler) Setup(
 	configFunction func(RabbitMQConnectionInterface, RabbitMQChannelInterface) error,
 	dialFunc func(string) (RabbitMQConnectionWrapperInterface, error)) {
 	r.createConnectionAndChannel(ctx, rabbitMQURL, configFunction, dialFunc)
-	// watch for any connection unexpected closures
-	if r.firstSetup {
-		r.firstSetup = false
-		go r.watchRabbitMQConnections(ctx, rabbitMQURL, configFunction, dialFunc)
-	}
+	go r.watchRabbitMQConnections(ctx, rabbitMQURL, configFunction, dialFunc)
 }
 
 func (r *RabbitMQConnectionHandler) createConnectionAndChannel(
@@ -164,7 +166,8 @@ func (r *RabbitMQConnectionHandler) watchRabbitMQConnections(
 	dialFunc func(string) (RabbitMQConnectionWrapperInterface, error)) {
 	for {
 		select {
-		case <-ctx.Done():
+		// previously ctx.Done() trigger was used, which raced against HTTP-side draining.
+		case <-r.stopCh:
 			r.logger.Info("stopped watching for rabbitmq connections")
 			r.closeRabbitMQConnections()
 			return
@@ -211,6 +214,10 @@ func (r *RabbitMQConnectionHandler) configConnectionAndChannel(configFunction fu
 		}
 	}
 	return err
+}
+
+func (r *RabbitMQConnectionHandler) Close() {
+	close(r.stopCh)
 }
 
 func (r *RabbitMQConnectionHandler) closeRabbitMQConnections() {

--- a/pkg/rabbit/connections_handler_test.go
+++ b/pkg/rabbit/connections_handler_test.go
@@ -28,13 +28,12 @@ import (
 
 func Test_ValidSetupRabbitMQ(t *testing.T) {
 	logger := zap.NewNop().Sugar()
-	ctx, cancelFunc := context.WithCancel(context.Background())
 	rabbitMQHelper := NewRabbitMQConnectionHandler(1, 100, logger).(*RabbitMQConnectionHandler)
-	rabbitMQHelper.Setup(ctx, "amqp://localhost:5672/%2f", ConfigTest, ValidDial)
+	rabbitMQHelper.Setup(context.Background(), "amqp://localhost:5672/%2f", ConfigTest, ValidDial)
 	if rabbitMQHelper.Connection == nil || rabbitMQHelper.Channel == nil {
 		t.Errorf("rabbitMQHelper connection and channel should be set %s %s", rabbitMQHelper.Connection, rabbitMQHelper.Channel)
 	}
-	cancelFunc()
+	rabbitMQHelper.Close() // stops the watcher; it no longer ends on ctx cancel
 }
 
 func Test_InvalidSetupRabbitMQ(t *testing.T) {
@@ -89,19 +88,18 @@ func Test_WatchConnectionsRabbitMQ(t *testing.T) {
 	for _, tt := range []struct {
 		name, endFunc string
 	}{{
-		name:    "end watcher by context cancel func",
-		endFunc: "cancel",
+		name:    "end watcher by closing stop channel",
+		endFunc: "stop",
 	}, {
-		name:    "reset watcher via connection and end via context cancel func",
+		name:    "reset watcher via connection and end by closing stop channel",
 		endFunc: "connection",
 	}, {
-		name:    "reset watcher via channel and end via context cancel func",
+		name:    "reset watcher via channel and end by closing stop channel",
 		endFunc: "channel",
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
 			tt := tt
 			t.Parallel()
-			ctx, cancelFunc := context.WithCancel(context.Background())
 			logger := zap.NewNop().Sugar()
 			// test invalid connection setup
 			rabbitMQHelper := NewRabbitMQConnectionHandler(1, 100, logger).(*RabbitMQConnectionHandler)
@@ -113,9 +111,9 @@ func Test_WatchConnectionsRabbitMQ(t *testing.T) {
 				} else if tt.endFunc == "channel" {
 					rabbitMQHelper.Channel.(*RabbitMQChannelMock).NotifyCloseChannel <- amqp091.ErrClosed
 				}
-				cancelFunc()
+				rabbitMQHelper.Close()
 			}()
-			rabbitMQHelper.watchRabbitMQConnections(ctx, "amqp://localhost:5672/%2f", nil, ValidDial)
+			rabbitMQHelper.watchRabbitMQConnections(context.Background(), "amqp://localhost:5672/%2f", nil, ValidDial)
 		})
 	}
 }

--- a/pkg/reconciler/broker/resources/ingress.go
+++ b/pkg/reconciler/broker/resources/ingress.go
@@ -127,16 +127,19 @@ func MakeIngressDeployment(args *IngressArgs) *appsv1.Deployment {
 					Containers: []corev1.Container{{
 						Image: args.Image,
 						Name:  ingressContainerName,
-						// LivenessProbe: &corev1.Probe{
-						// 	Handler: corev1.Handler{
-						// 		HTTPGet: &corev1.HTTPGetAction{
-						// 			Path: "/healthz",
-						// 			Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
-						// 		},
-						// 	},
-						// 	InitialDelaySeconds: 5,
-						// 	PeriodSeconds:       2,
-						// },
+						// another side for the #1669 - trip readiness
+						// and via drain as soon as ctx.Done closed
+						// be aware of QuietPeriod!
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/",
+									Port: intstr.FromInt(8080),
+								},
+							},
+							PeriodSeconds:    2,
+							FailureThreshold: 1,
+						},
 						Env: envs,
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8080,

--- a/pkg/reconciler/broker/resources/ingress_test.go
+++ b/pkg/reconciler/broker/resources/ingress_test.go
@@ -94,6 +94,16 @@ func TestMakeIngressDeployment(t *testing.T) {
 					Containers: []corev1.Container{{
 						Image: image,
 						Name:  "ingress",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/",
+									Port: intstr.FromInt(8080),
+								},
+							},
+							PeriodSeconds:    2,
+							FailureThreshold: 1,
+						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("50m"),

--- a/test/e2e/broker_test.go
+++ b/test/e2e/broker_test.go
@@ -21,9 +21,14 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	brokere2e "knative.dev/eventing-rabbitmq/test/e2e/config/broker"
 	"knative.dev/eventing-rabbitmq/test/e2e/config/brokersecret"
 	"knative.dev/eventing-rabbitmq/test/e2e/config/brokertrigger"
@@ -32,6 +37,7 @@ import (
 	smokebrokere2e "knative.dev/eventing-rabbitmq/test/e2e/config/smoke/broker"
 	smokebrokertriggere2e "knative.dev/eventing-rabbitmq/test/e2e/config/smoke/brokertrigger"
 	brokerresources "knative.dev/eventing/test/rekt/resources/broker"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
@@ -74,6 +80,96 @@ func DirectTestBroker() *feature.Feature {
 			})
 	f.Teardown("Delete feature resources", f.DeleteResources)
 	return f
+}
+
+const ingressRestartEventCount = 60
+
+// start sending events and od restarts, all events must be sent and all must
+// be received. see #1669
+func BrokerIngressRollingRestartNoEventLoss() *feature.Feature {
+	f := new(feature.Feature)
+	prober := eventshub.NewProber()
+	prober.SetTargetResource(brokerresources.GVR(), "testbroker")
+	prober.SenderFullEvents(ingressRestartEventCount)
+
+	f.Setup("install test resources", brokertrigger.Install(brokertrigger.Topology{
+		Triggers: []duckv1.KReference{
+			{
+				Kind: "Service",
+				Name: "recorder",
+			},
+		},
+	}))
+	f.Setup("RabbitMQ broker goes ready", AllGoReady)
+	f.Requirement("start streaming events", prober.SenderInstall("source"))
+
+	const minSentBeforeRestart = 5
+	f.Requirement("rolling-restart the ingress mid-stream", rolloutRestartAndWait("testbroker-broker-ingress", prober, "source", minSentBeforeRestart))
+
+	f.Assert("ingress accepted every event during the restart", prober.AssertSentAll("source"))
+
+	f.Assert("recorder received every event", func(ctx context.Context, t feature.T) {
+		eventshub.StoreFromContext(ctx, "recorder").AssertExact(ctx, t, ingressRestartEventCount)
+	})
+
+	f.Teardown("Delete feature resources", f.DeleteResources)
+	return f
+}
+
+func rolloutRestartAndWait(deploymentName string, prober *eventshub.EventProber, senderPrefix string, minSent int) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		ns := environment.FromContext(ctx).Namespace()
+		deployments := kubeclient.Get(ctx).AppsV1().Deployments(ns)
+
+		if err := wait.PollUntilContextTimeout(ctx, time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			_, err := deployments.Get(ctx, deploymentName, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return err == nil, err
+		}); err != nil {
+			t.Fatalf("ingress deployment %s never appeared: %v", deploymentName, err)
+		}
+
+		// wait until the sender is actually streaming so the rollout overlaps in-flight traffic.
+		if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 2*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					done = false
+				}
+			}()
+			return len(prober.SentBy(ctx, senderPrefix)) >= minSent, nil
+		}); err != nil {
+			t.Fatalf("sender %q did not reach %d sent events before rollout: %v", senderPrefix, minSent, err)
+		}
+
+		// Trigger a rollout the same way `kubectl rollout restart` does.
+		patch := []byte(fmt.Sprintf(
+			`{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":%q}}}}}`,
+			time.Now().Format(time.RFC3339)))
+		updated, err := deployments.Patch(ctx, deploymentName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+		if err != nil {
+			t.Fatalf("failed to trigger rollout restart of %s: %v", deploymentName, err)
+		}
+		targetGen := updated.Generation
+
+		if err := wait.PollUntilContextTimeout(ctx, time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+			d, err := deployments.Get(ctx, deploymentName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			desired := int32(1)
+			if d.Spec.Replicas != nil {
+				desired = *d.Spec.Replicas
+			}
+			return d.Status.ObservedGeneration >= targetGen &&
+				d.Status.UpdatedReplicas == desired &&
+				d.Status.Replicas == desired &&
+				d.Status.AvailableReplicas == desired, nil
+		}); err != nil {
+			t.Fatalf("ingress rollout did not complete: %v", err)
+		}
+	}
 }
 
 func DirectTestBrokerConnectionSecret() *feature.Feature {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -124,6 +124,22 @@ func TestBrokerDirectSelfSignedCerts(t *testing.T) {
 	env.Finish()
 }
 
+// TestBrokerIngressRollingRestart makes sure a rolling restart of the broker
+// ingress does not fail or drop in-flight events (issue #1669).
+func TestBrokerIngressRollingRestart(t *testing.T) {
+	t.Parallel()
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithObservabilityConfig,
+		k8s.WithEventListener,
+	)
+	env.Test(ctx, t, RabbitMQCluster())
+	env.Test(ctx, t, RecorderFeature())
+	env.Test(ctx, t, BrokerIngressRollingRestartNoEventLoss())
+	env.Finish()
+}
+
 // TestBrokerDLQ makes sure a Broker delivers events to a DLQ.
 func TestBrokerDLQ(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
# Changes

:bug #1669 fixes RabbitMQ connection closure vs Drain race.

/kind bug

Fixes #1669

**Release Note**

```release-note
Fix RabbitMQ  connection close vs HTTP drain race during ingress shutdown (#1669) 
```

@dprotaso it's been some time since I contributed here. Could you please have a look if I'm doing the right thing here?

Two things worth noting - had to update kind version and the e2e test - it looks like the standard mechanics sends message one by one and rather infrequently (I suspect 1msg/sec) so it is hard to trigger the situation that @eloo-abi had.
